### PR TITLE
Pass extra token and gas pricing information when posting a bundle

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,6 @@ import {
   type Execution,
   type MetaIntent,
   type PostOrderBundleResult,
-  type TokenTransfer,
 } from "@rhinestone/sdk/orchestrator";
 import {
   Account,
@@ -165,6 +164,9 @@ export const processIntent = async (intent: Intent) => {
           ["address", "bytes"],
           [targetSmartAccount.factory, targetSmartAccount.factoryData],
         ),
+        tokenPrices: orderPath[0].tokenPrices,
+        gasPrices: orderPath[0].gasPrices,
+        opGasParams: orderPath[0].opGasParams,
       },
     ]);
 


### PR DESCRIPTION
This goes in tandem with ticket [RHI-1927](https://linear.app/rhinestone/issue/RHI-1927/add-gas-price-and-gas-cost-estimation-logs-to-orch) now that the `POST /bundles` endpoint will require it as well.