### PR TITLE
impv funding local_testnet check

### DIFF
--- a/src/funding.ts
+++ b/src/funding.ts
@@ -74,7 +74,7 @@ export const fundAccount = async ({
   sourceChains: string[];
   sourceTokens: string[];
 }) => {
-  if (process.env.LOCAL_TESTNET) {
+  if (process.env.LOCAL_TESTNET?.toString()==="true") {
     for (const sourceChain of sourceChains) {
       const chain = getChain(sourceChain);
 


### PR DESCRIPTION
I believe that LOCAL_TESTNET=false would still qualify as `true` here. Only if LOCAL_TESTNET env var was entirely removed would it skip this part

I had to make this change on my local bundler to get it working right - otherwise it was always trying to do local funding