### PR TITLE
feat: add deposit mode for cross-chain deposits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ DEFAULT_TOKEN_RECIPIENT=""
 
 # set to true when using locally hosted testnets (optional)
 LOCAL_TESTNET=false
+
+# ngrok authtoken for deposit webhook support (optional, falls back to balance polling)
+NGROK_AUTHTOKEN=""

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Set the API key for your target environment in `.env`. The owner private key is 
 | `LOCAL_API_KEY` | API key for local orchestrator |
 | `DEFAULT_TOKEN_RECIPIENT` | Default recipient address (falls back to owner) |
 | `LOCAL_TESTNET` | Set to `true` to enable local testnet funding |
+| `NGROK_AUTHTOKEN` | Ngrok auth token for deposit webhook support (optional, falls back to balance polling) |
 
 ## Commands
 
@@ -45,7 +46,7 @@ Replay saved intents from the `intents/` directory.
 | `filename` | Replay a specific file (`.json` extension optional) |
 | `--all` | Replay all intents without prompting |
 | `--env <prod\|dev\|local>` | Set environment |
-| `--mode <execute\|simulate>` | Set execution mode |
+| `--mode <execute\|simulate\|route\|deposit>` | Set execution mode |
 | `--async [delay]` | Run in parallel with optional delay in ms (default: 2500) |
 | `--verbose` | Print `intentOp` and `intentCost` after transaction preparation |
 
@@ -55,7 +56,18 @@ Examples:
 pnpm replay                                        # interactive
 pnpm replay my-intent --env prod --mode execute     # specific file
 pnpm replay --all --env dev --async 3000            # all, parallel
+pnpm replay my-deposit --env dev --mode deposit     # deposit mode
 ```
+
+### Deposit mode
+
+`--mode deposit` tests the deposit service end-to-end. It creates a session-enabled deposit account, funds it via an intent, and waits for the deposit service to bridge funds to the target chain.
+
+Deposit intents require:
+- Exactly 1 source chain (the deposit chain)
+- `sourceAssets` in exact input format with amounts
+
+If `NGROK_AUTHTOKEN` is set, deposit mode uses outbound webhooks from the deposit service for faster bridge detection and timing breakdown (detect, route, bridge). Otherwise it falls back to balance polling.
 
 ## Intent JSON format
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
+    "@ngrok/ngrok": "^1.7.0",
     "@rhinestone/sdk": "^1.2.13",
     "abitype": "^1.0.8",
     "dotenv": "^16.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@inquirer/prompts':
         specifier: ^7.4.1
         version: 7.8.4(@types/node@22.18.1)
+      '@ngrok/ngrok':
+        specifier: ^1.7.0
+        version: 1.7.0
       '@rhinestone/sdk':
         specifier: ^1.2.13
         version: 1.2.13(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
@@ -380,6 +383,87 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@ngrok/ngrok-android-arm64@1.7.0':
+    resolution: {integrity: sha512-8tco3ID6noSaNy+CMS7ewqPoIkIM6XO5COCzsUp3Wv3XEbMSyn65RN6cflX2JdqLfUCHcMyD0ahr9IEiHwqmbQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@ngrok/ngrok-darwin-arm64@1.7.0':
+    resolution: {integrity: sha512-+dmJSOzSO+MNDVrPOca2yYDP1W3KfP4qOlAkarIeFRIfqonQwq3QCBmcR7HAlZocLsSqEwyG6KP4RRvAuT0WGQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ngrok/ngrok-darwin-universal@1.7.0':
+    resolution: {integrity: sha512-fDEfewyE2pWGFBhOSwQZObeHUkc65U1l+3HIgSOe094TMHsqmyJD0KTCgW9KSn0VP4OvDZbAISi1T3nvqgZYhQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@ngrok/ngrok-darwin-x64@1.7.0':
+    resolution: {integrity: sha512-+fwMi5uHd9G8BS42MMa9ye6exI5lwTcjUO6Ut497Vu0qgLONdVRenRqnEePV+Q3KtQR7NjqkMnomVfkr9MBjtw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ngrok/ngrok-freebsd-x64@1.7.0':
+    resolution: {integrity: sha512-2OGgbrjy3yLRrqAz5N6hlUKIWIXSpR5RjQa2chtZMsSbszQ6c9dI+uVQfOKAeo05tHMUgrYAZ7FocC+ig0dzdQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@ngrok/ngrok-linux-arm-gnueabihf@1.7.0':
+    resolution: {integrity: sha512-SN9YIfEQiR9xN90QVNvdgvAemqMLoFVSeTWZs779145hQMhvF9Qd9rnWi6J+2uNNK10OczdV1oc/nq1es7u/3g==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-arm64-gnu@1.7.0':
+    resolution: {integrity: sha512-KDMgzPKFU2kbpVSaA2RZBBia5IPdJEe063YlyVFnSMJmPYWCUnMwdybBsucXfV9u1Lw/ZjKTKotIlbTWGn3HGw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-arm64-musl@1.7.0':
+    resolution: {integrity: sha512-e66vUdVrBlQ0lT9ZdamB4U604zt5Gualt8/WVcUGzbu8s5LajWd6g/mzZCUjK4UepjvMpfgmCp1/+rX7Rk8d5A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-x64-gnu@1.7.0':
+    resolution: {integrity: sha512-M6gF0DyOEFqXLfWxObfL3bxYZ4+PnKBHuyLVaqNfFN9Y5utY2mdPOn5422Ppbk4XoIK5/YkuhRqPJl/9FivKEw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ngrok/ngrok-linux-x64-musl@1.7.0':
+    resolution: {integrity: sha512-4Ijm0dKeoyzZTMaYxR2EiNjtlK81ebflg/WYIO1XtleFrVy4UJEGnxtxEidYoT4BfCqi4uvXiK2Mx216xXKvog==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ngrok/ngrok-win32-arm64-msvc@1.7.0':
+    resolution: {integrity: sha512-u7qyWIJI2/YG1HTBnHwUR1+Z2tyGfAsUAItJK/+N1G0FeWJhIWQvSIFJHlaPy4oW1Dc8mSDBX9qvVsiQgLaRFg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ngrok/ngrok-win32-ia32-msvc@1.7.0':
+    resolution: {integrity: sha512-/UdYUsLNv/Q8j9YJsyIfq/jLCoD8WP+NidouucTUzSoDtmOsXBBT3itLrmPiZTEdEgKiFYLuC1Zon8XQQvbVLA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ngrok/ngrok-win32-x64-msvc@1.7.0':
+    resolution: {integrity: sha512-UFJg/duEWzZlLkEs61Gz6/5nYhGaKI62I8dvUGdBR3NCtIMagehnFaFxmnXZldyHmCM8U0aCIFNpWRaKcrQkoA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ngrok/ngrok@1.7.0':
+    resolution: {integrity: sha512-P06o9TpxrJbiRbHQkiwy/rUrlXRupc+Z8KT4MiJfmcdWxvIdzjCaJOdnNkcOTs6DMyzIOefG5tvk/HLdtjqr0g==}
+    engines: {node: '>= 10'}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -821,6 +905,61 @@ snapshots:
   '@inquirer/type@3.0.8(@types/node@22.18.1)':
     optionalDependencies:
       '@types/node': 22.18.1
+
+  '@ngrok/ngrok-android-arm64@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-darwin-arm64@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-darwin-universal@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-darwin-x64@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-freebsd-x64@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-linux-arm-gnueabihf@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-linux-arm64-gnu@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-linux-arm64-musl@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-linux-x64-gnu@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-linux-x64-musl@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-win32-arm64-msvc@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-win32-ia32-msvc@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok-win32-x64-msvc@1.7.0':
+    optional: true
+
+  '@ngrok/ngrok@1.7.0':
+    optionalDependencies:
+      '@ngrok/ngrok-android-arm64': 1.7.0
+      '@ngrok/ngrok-darwin-arm64': 1.7.0
+      '@ngrok/ngrok-darwin-universal': 1.7.0
+      '@ngrok/ngrok-darwin-x64': 1.7.0
+      '@ngrok/ngrok-freebsd-x64': 1.7.0
+      '@ngrok/ngrok-linux-arm-gnueabihf': 1.7.0
+      '@ngrok/ngrok-linux-arm64-gnu': 1.7.0
+      '@ngrok/ngrok-linux-arm64-musl': 1.7.0
+      '@ngrok/ngrok-linux-x64-gnu': 1.7.0
+      '@ngrok/ngrok-linux-x64-musl': 1.7.0
+      '@ngrok/ngrok-win32-arm64-msvc': 1.7.0
+      '@ngrok/ngrok-win32-ia32-msvc': 1.7.0
+      '@ngrok/ngrok-win32-x64-msvc': 1.7.0
 
   '@noble/ciphers@1.3.0': {}
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -373,6 +373,7 @@ export const collectUserInput = async (): Promise<{
       },
       { name: 'Simulate', value: 'simulate' },
       { name: 'Route', value: 'route' },
+      { name: 'Deposit', value: 'deposit' },
     ],
   })
 
@@ -533,6 +534,7 @@ export const getReplayParams = async () => {
         { name: 'Execute', value: 'execute' },
         { name: 'Simulate', value: 'simulate' },
         { name: 'Route', value: 'route' },
+        { name: 'Deposit', value: 'deposit' },
       ],
     })
   }

--- a/src/deposit-webhook.ts
+++ b/src/deposit-webhook.ts
@@ -1,0 +1,291 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto'
+import { createServer, type Server } from 'node:http'
+import ngrok from '@ngrok/ngrok'
+import type { Address } from 'viem'
+import { ts } from './main.js'
+
+export interface WebhookBridgeResult {
+  deposit: { transactionHash: string; sender: string }
+  source: {
+    transactionHash: string
+    chain: string
+    amount: string
+    asset: string
+  }
+  destination: {
+    transactionHash: string
+    chain: string
+    amount: string
+    asset: string
+  }
+  account: string
+  timings: {
+    detect: number
+    route: number
+    bridge: number
+    total: number
+  }
+}
+
+export interface WebhookListener {
+  /** Record the on-chain timestamp of the funding fill tx */
+  markFundingComplete(depositAddress: Address, fillTimestamp: number): void
+  waitForBridge(
+    depositAddress: Address,
+    timeout: number,
+  ): Promise<WebhookBridgeResult>
+  cleanup(): Promise<void>
+}
+
+interface PendingBridge {
+  resolve: (result: WebhookBridgeResult) => void
+  reject: (error: Error) => void
+}
+
+interface EventTimestamps {
+  fundingComplete?: number
+  depositReceived?: number
+  bridgeStarted?: number
+  bridgeComplete?: number
+}
+
+interface WebhookPayload {
+  version: string
+  type: string
+  time: string
+  data: any
+}
+
+function verifySignature(
+  rawBody: string,
+  secret: string,
+  signatureHeader: string | undefined,
+): boolean {
+  if (!signatureHeader) return false
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex')
+  const provided = signatureHeader.replace('sha256=', '')
+  if (expected.length !== provided.length) return false
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(provided))
+}
+
+export async function createWebhookListener(
+  serviceUrl: string,
+  apiKey: string,
+): Promise<WebhookListener> {
+  const secret = randomBytes(32).toString('hex')
+  const pending = new Map<string, PendingBridge>()
+  const timestamps = new Map<string, EventTimestamps>()
+
+  // Start local HTTP server on random port
+  const server = await new Promise<Server>((resolve) => {
+    const srv = createServer((req, res) => {
+      let body = ''
+      req.on('data', (chunk) => {
+        body += chunk
+      })
+      req.on('end', () => {
+        const sig = req.headers['x-webhook-signature'] as string | undefined
+        if (!verifySignature(body, secret, sig)) {
+          res.writeHead(401)
+          res.end()
+          return
+        }
+
+        res.writeHead(200)
+        res.end()
+
+        try {
+          const payload = JSON.parse(body) as WebhookPayload
+          handleEvent(payload)
+        } catch {
+          // ignore parse errors
+        }
+      })
+    })
+    srv.listen(0, '127.0.0.1', () => resolve(srv))
+  })
+
+  const port = (server.address() as { port: number }).port
+
+  // Start ngrok tunnel
+  const listener = await ngrok.forward({
+    addr: port,
+    authtoken_from_env: true,
+  })
+  const webhookUrl = listener.url()!
+  console.log(
+    `${ts()} Deposit: Webhook listener started at ${webhookUrl} (port ${port})`,
+  )
+
+  // Register webhook URL with deposit service
+  const setupResponse = await fetch(`${serviceUrl}/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+    body: JSON.stringify({
+      params: { webhookUrl, webhookSecret: secret },
+    }),
+  })
+  if (!setupResponse.ok) {
+    const text = await setupResponse.text()
+    // Clean up on failure
+    await listener.close()
+    server.close()
+    throw new Error(
+      `Failed to set webhook URL (${setupResponse.status}): ${text}`,
+    )
+  }
+
+  function getTimestamps(account: string): EventTimestamps {
+    let ts = timestamps.get(account)
+    if (!ts) {
+      ts = {}
+      timestamps.set(account, ts)
+    }
+    return ts
+  }
+
+  function buildTimings(ts: EventTimestamps) {
+    const detect =
+      ts.fundingComplete && ts.depositReceived
+        ? ts.depositReceived - ts.fundingComplete
+        : 0
+    const route =
+      ts.depositReceived && ts.bridgeStarted
+        ? ts.bridgeStarted - ts.depositReceived
+        : 0
+    // If bridge-started was never received, measure from detect to complete
+    const bridge = ts.bridgeStarted && ts.bridgeComplete
+      ? ts.bridgeComplete - ts.bridgeStarted
+      : ts.depositReceived && ts.bridgeComplete
+        ? ts.bridgeComplete - ts.depositReceived
+        : 0
+    const total =
+      ts.fundingComplete && ts.bridgeComplete
+        ? ts.bridgeComplete - ts.fundingComplete
+        : 0
+    return { detect, route, bridge, total }
+  }
+
+  function handleEvent(payload: WebhookPayload) {
+    const { type, data } = payload
+    const account = data?.account?.toLowerCase()
+    const now = Date.now()
+
+    switch (type) {
+      case 'deposit-received': {
+        getTimestamps(account).depositReceived = now
+        console.log(`${ts()} Deposit: [webhook] Deposit detected by service (amount: ${data?.amount ?? 'unknown'})`)
+        break
+      }
+      case 'bridge-started': {
+        getTimestamps(account).bridgeStarted = now
+        console.log(`${ts()} Deposit: [webhook] Bridge started`)
+        break
+      }
+      case 'bridge-complete': {
+        const evTs = getTimestamps(account)
+        evTs.bridgeComplete = now
+        const timings = buildTimings(evTs)
+        timestamps.delete(account)
+        const p = pending.get(account)
+        if (p) {
+          pending.delete(account)
+          p.resolve({
+            ...(data as Omit<WebhookBridgeResult, 'timings'>),
+            timings,
+          })
+        }
+        break
+      }
+      case 'bridge-failed': {
+        console.log(
+          `${ts()} Deposit: [webhook] Bridge failed: ${data?.errorCode ?? 'unknown'} - ${data?.message ?? ''}`,
+        )
+        timestamps.delete(account)
+        const p = pending.get(account)
+        if (p) {
+          pending.delete(account)
+          p.reject(
+            new Error(
+              `Bridge failed: ${data?.errorCode ?? 'unknown'}${data?.message ? ` - ${data.message}` : ''}`,
+            ),
+          )
+        }
+        break
+      }
+      case 'error':
+        console.warn(
+          `${ts()} Deposit: [webhook] Error event: ${data?.error?.message ?? 'unknown'}`,
+        )
+        break
+      default:
+        console.log(`${ts()} Deposit: [webhook] Unknown event: ${type}`)
+    }
+  }
+
+  return {
+    markFundingComplete(depositAddress: Address, fillTimestamp: number) {
+      const key = depositAddress.toLowerCase()
+      getTimestamps(key).fundingComplete = fillTimestamp
+    },
+
+    waitForBridge(depositAddress: Address, timeout: number) {
+      return new Promise<WebhookBridgeResult>((resolve, reject) => {
+        const key = depositAddress.toLowerCase()
+        const timer = setTimeout(() => {
+          pending.delete(key)
+          timestamps.delete(key)
+          reject(
+            new Error(
+              `Webhook timeout: bridge-complete not received within ${timeout}ms`,
+            ),
+          )
+        }, timeout)
+
+        pending.set(key, {
+          resolve: (result) => {
+            clearTimeout(timer)
+            resolve(result)
+          },
+          reject: (error) => {
+            clearTimeout(timer)
+            reject(error)
+          },
+        })
+      })
+    },
+
+    async cleanup() {
+      // Clear webhook URL on the deposit service
+      try {
+        await fetch(`${serviceUrl}/setup`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'x-api-key': apiKey,
+          },
+          body: JSON.stringify({
+            params: { webhookUrl: null, webhookSecret: null },
+          }),
+        })
+      } catch {
+        // best-effort cleanup
+      }
+
+      // Close tunnel and server
+      try {
+        await listener.close()
+      } catch {
+        // ignore
+      }
+      server.close()
+
+      // Reject any pending waiters
+      for (const [key, p] of pending) {
+        p.reject(new Error('Webhook listener shut down'))
+        pending.delete(key)
+      }
+      timestamps.clear()
+    },
+  }
+}

--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -314,9 +314,7 @@ export async function runDepositMode(
       {
         chain: targetChain.id,
         token: targetTokenAddress,
-        ...(intent.tokenRecipient
-          ? { recipient: intent.tokenRecipient as Address }
-          : {}),
+        recipient,
       },
     )
     console.log(`${ts()} Deposit: Registration complete`)

--- a/src/deposit.ts
+++ b/src/deposit.ts
@@ -1,0 +1,400 @@
+import {
+  getTokenAddress,
+  type RhinestoneAccount as RhinestoneAccountType,
+  RhinestoneSDK,
+  type Session,
+} from '@rhinestone/sdk'
+import { toViewOnlyAccount } from '@rhinestone/sdk/utils'
+import {
+  type Address,
+  type Chain,
+  createPublicClient,
+  erc20Abi,
+  type Hex,
+  http,
+  isAddress,
+} from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import {
+  createRhinestoneAccount,
+  processIntent,
+  type RhinestoneAccount,
+  ts,
+} from './main.js'
+import type { Intent, Token, TokenSymbol } from './types.js'
+import { getChain } from './utils/chains.js'
+import { getDepositServiceConfig } from './utils/environments.js'
+
+function jsonStringify(value: unknown): string {
+  return JSON.stringify(value, (_, v) =>
+    typeof v === 'bigint' ? v.toString() : v,
+  )
+}
+
+const POLL_INTERVAL = 1_000
+const POLL_TIMEOUT = 90_000
+
+// --- Deposit chain validation ---
+
+interface DepositChainEntry {
+  name: string
+  testnet: boolean
+  deposit: boolean
+  destination: boolean
+  supportedTokens:
+    | 'all'
+    | { symbol: string; address: string; decimals: number }[]
+}
+
+function toCaip2(chainId: number): string {
+  return `eip155:${chainId}`
+}
+
+async function fetchSupportedDepositChains(
+  orchestratorUrl: string,
+): Promise<Set<string>> {
+  const response = await fetch(`${orchestratorUrl}/deposit-processor/chains`)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch deposit chains: ${response.status} ${response.statusText}`,
+    )
+  }
+  const data = (await response.json()) as Record<string, DepositChainEntry>
+  const depositEnabledChainIds = new Set<string>()
+  for (const [chainId, chain] of Object.entries(data)) {
+    if (chain.deposit) {
+      depositEnabledChainIds.add(chainId)
+    }
+  }
+  return depositEnabledChainIds
+}
+
+// --- Deposit account creation ---
+
+interface DepositAccountSetup {
+  account: RhinestoneAccountType
+  address: Address
+  factory: Address
+  factoryData: Hex
+  sessionDetails: {
+    hashesAndChainIds: { chainId: bigint; sessionDigest: Hex }[]
+    signature: Hex
+  }
+}
+
+async function createDepositAccount(
+  environmentString: string,
+  chains: Chain[],
+  signerAddress: Address,
+): Promise<DepositAccountSetup> {
+  const owner = privateKeyToAccount(process.env.OWNER_PRIVATE_KEY! as Hex)
+  const depositConfig = getDepositServiceConfig(environmentString)
+
+  const rhinestone = new RhinestoneSDK({
+    apiKey: depositConfig.apiKey,
+    endpointUrl: depositConfig.orchestratorUrl,
+    useDevContracts: false,
+  })
+
+  const account = await rhinestone.createAccount({
+    account: {
+      type: 'nexus' as const,
+      salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+    },
+    owners: { type: 'ecdsa' as const, accounts: [owner] },
+    experimental_sessions: { enabled: true },
+  })
+
+  const { factory, factoryData } = account.getInitData()
+  const address = account.getAddress()
+
+  const sessionSignerAccount = toViewOnlyAccount(signerAddress)
+  const sessions: Session[] = chains.map((chain) => ({
+    owners: { type: 'ecdsa' as const, accounts: [sessionSignerAccount] },
+    chain,
+  }))
+
+  const sessionDetails = await account.experimental_getSessionDetails(sessions)
+  const enableSignature =
+    await account.experimental_signEnableSession(sessionDetails)
+
+  return {
+    account,
+    address,
+    factory,
+    factoryData,
+    sessionDetails: {
+      hashesAndChainIds: sessionDetails.hashesAndChainIds,
+      signature: enableSignature,
+    },
+  }
+}
+
+// --- Deposit service API calls ---
+
+async function setupClient(
+  serviceUrl: string,
+  apiKey: string,
+  sponsored: boolean,
+  depositChainId: number,
+  targetChainId: number,
+): Promise<void> {
+  const sponsorship = sponsored
+    ? {
+        [`eip155:${depositChainId}`]: {
+          gas: 'all' as const,
+          swap: 'all' as const,
+          bridging: 'all' as const,
+        },
+        [`eip155:${targetChainId}`]: {
+          gas: 'all' as const,
+          swap: 'all' as const,
+          bridging: 'all' as const,
+        },
+      }
+    : undefined
+
+  const response = await fetch(`${serviceUrl}/setup`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+    body: JSON.stringify({
+      params: {
+        ...(sponsorship ? { sponsorship } : {}),
+      },
+    }),
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Setup failed (${response.status}): ${text}`)
+  }
+}
+
+async function registerAccount(
+  serviceUrl: string,
+  apiKey: string,
+  accountSetup: DepositAccountSetup,
+  target: { chain: number; token: Address; recipient?: Address },
+): Promise<void> {
+  const response = await fetch(`${serviceUrl}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+    body: jsonStringify({
+      account: {
+        address: accountSetup.address,
+        accountParams: {
+          factory: accountSetup.factory,
+          factoryData: accountSetup.factoryData,
+          sessionDetails: accountSetup.sessionDetails,
+        },
+        target,
+      },
+    }),
+  })
+  if (!response.ok) {
+    const text = await response.text()
+    throw new Error(`Register failed (${response.status}): ${text}`)
+  }
+}
+
+// --- Balance polling ---
+
+async function pollBalance(
+  chain: Chain,
+  token: Address,
+  address: Address,
+  timeout: number,
+  minBalance = 0n,
+): Promise<bigint> {
+  const publicClient = createPublicClient({ chain, transport: http() })
+  const startTime = Date.now()
+
+  while (Date.now() - startTime < timeout) {
+    const balance = await publicClient.readContract({
+      address: token,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [address],
+    })
+
+    if (balance > minBalance) {
+      console.log(
+        `${ts()} Deposit: Balance updated on ${chain.name}: ${balance}`,
+      )
+      return balance
+    }
+
+    console.log(`${ts()} Deposit: Waiting for balance on ${chain.name}...`)
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL))
+  }
+
+  throw new Error(
+    `Timeout: Balance did not increase on ${chain.name} within ${timeout}ms`,
+  )
+}
+
+// --- Main orchestration ---
+
+export async function runDepositMode(
+  intent: Intent,
+  environmentString: string,
+  normalAccount: RhinestoneAccount,
+  verbose?: boolean,
+): Promise<void> {
+  // 1. Validate
+  if (intent.sourceChains.length !== 1) {
+    throw new Error(
+      `Deposit mode requires exactly 1 source chain (deposit chain), got ${intent.sourceChains.length}`,
+    )
+  }
+
+  const depositConfig = getDepositServiceConfig(environmentString)
+  const depositChain = getChain(intent.sourceChains[0])
+  const targetChain = getChain(intent.targetChain)
+
+  console.log(`${ts()} Deposit: ${depositChain.name} → ${targetChain.name}`)
+
+  // 2. Validate deposit chain is supported
+  console.log(`${ts()} Deposit: Checking supported deposit chains...`)
+  const supportedChains = await fetchSupportedDepositChains(
+    depositConfig.orchestratorUrl,
+  )
+  if (!supportedChains.has(toCaip2(depositChain.id))) {
+    throw new Error(
+      `Unsupported deposit chain: ${depositChain.name} (${depositChain.id}). Chain does not have deposit enabled.`,
+    )
+  }
+
+  // 3. Resolve target token address on Z
+  const targetTokenSymbol = intent.targetTokens[0].symbol
+  const targetTokenAddress = isAddress(targetTokenSymbol)
+    ? targetTokenSymbol
+    : getTokenAddress(targetTokenSymbol as TokenSymbol, targetChain.id)
+
+  // 4. Determine recipient on Z
+  const recipient = intent.tokenRecipient
+    ? (intent.tokenRecipient as Address)
+    : normalAccount.getAddress()
+
+  // 5. Create deposit account with sessions
+  console.log(`${ts()} Deposit: Creating session-enabled deposit account...`)
+  const depositAccountSetup = await createDepositAccount(
+    environmentString,
+    [depositChain, targetChain],
+    depositConfig.signerAddress,
+  )
+  const depositAddress = depositAccountSetup.address
+  console.log(`${ts()} Deposit: Deposit account address: ${depositAddress}`)
+
+  // 6. Register with deposit service (always re-register to handle
+  // changing deposit chains or targets between intents)
+  console.log(`${ts()} Deposit: Registering with deposit service...`)
+  await setupClient(
+    depositConfig.url,
+    depositConfig.apiKey,
+    intent.sponsored,
+    depositChain.id,
+    targetChain.id,
+  )
+  await registerAccount(
+    depositConfig.url,
+    depositConfig.apiKey,
+    depositAccountSetup,
+    {
+      chain: targetChain.id,
+      token: targetTokenAddress,
+      ...(intent.tokenRecipient
+        ? { recipient: intent.tokenRecipient as Address }
+        : {}),
+    },
+  )
+  console.log(`${ts()} Deposit: Registration complete`)
+
+  // 7. Record initial balance on Z
+  const targetTokenAddressOnZ = targetTokenAddress
+  const publicClient = createPublicClient({
+    chain: targetChain,
+    transport: http(),
+  })
+  const initialBalance = await publicClient.readContract({
+    address: targetTokenAddressOnZ,
+    abi: erc20Abi,
+    functionName: 'balanceOf',
+    args: [recipient],
+  })
+  console.log(
+    `${ts()} Deposit: Initial balance on ${targetChain.name}: ${initialBalance}`,
+  )
+
+  // 8. Build and execute funding intent (send to deposit address on Y)
+  // Derive targetTokens from sourceAssets: the source tokens with amounts become
+  // the exact target on the deposit chain. sourceAssets must be in exact input format.
+  if (!intent.sourceAssets || !Array.isArray(intent.sourceAssets)) {
+    throw new Error(
+      'Deposit mode requires sourceAssets in exact input format: [{ chain, token, amount }]',
+    )
+  }
+  const sourceAssetConfigs = intent.sourceAssets as {
+    chain: string
+    token: string
+    amount?: string
+  }[]
+  const missingAmounts = sourceAssetConfigs.filter((c) => !c.amount)
+  if (missingAmounts.length > 0) {
+    throw new Error(
+      `Deposit mode requires all sourceAssets to have amounts. Missing amounts for: ${missingAmounts.map((c) => c.token).join(', ')}`,
+    )
+  }
+  const fundingTargetTokens: Token[] = sourceAssetConfigs.map((config) => ({
+    symbol: config.token,
+    amount: config.amount,
+  }))
+
+  // Create a prod account for the funding intent — deposit mode always uses
+  // prod orchestrator and prod contracts, regardless of selected environment.
+  console.log(`${ts()} Deposit: Creating prod account for funding intent...`)
+  const prodAccount = await createRhinestoneAccount('prod')
+
+  console.log(`${ts()} Deposit: Funding deposit address via intent...`)
+  const fundingIntent: Intent = {
+    targetChain: intent.sourceChains[0],
+    targetTokens: fundingTargetTokens,
+    sourceChains: [],
+    sourceTokens: [],
+    tokenRecipient: depositAddress,
+    settlementLayers: [],
+    sponsored: false,
+  }
+
+  const fillResult = await processIntent(
+    fundingIntent,
+    'prod',
+    'execute',
+    prodAccount,
+    verbose,
+  )
+
+  if (!fillResult) {
+    throw new Error('Funding intent returned no result')
+  }
+
+  console.log(
+    `${ts()} Deposit: Funding complete. Fill hash: ${fillResult.fill.hash} on chain ${fillResult.fill.chainId}`,
+  )
+  if (verbose) {
+    console.dir(fillResult, { depth: null })
+  }
+
+  // 9. Poll balance on Z until it increases
+  console.log(`${ts()} Deposit: Polling for balance on ${targetChain.name}...`)
+  const finalBalance = await pollBalance(
+    targetChain,
+    targetTokenAddressOnZ,
+    recipient,
+    POLL_TIMEOUT,
+    initialBalance,
+  )
+
+  console.log(
+    `${ts()} Deposit: Success! Final balance on ${targetChain.name}: ${finalBalance} (was ${initialBalance})`,
+  )
+}

--- a/src/get-address.ts
+++ b/src/get-address.ts
@@ -38,7 +38,7 @@ export const main = async () => {
   const rhinestone = new RhinestoneSDK({
     apiKey: rhinestoneApiKey,
     endpointUrl: orchestratorUrl,
-    useDevContracts: environment.url !== undefined,
+    useDevContracts: environment.useDevContracts,
   })
   const rhinestoneAccount = await rhinestone.createAccount({
     owners: {

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,7 +281,9 @@ export const processIntent = async (
     .join(', ')
 
   // prepare the recipient label
-  const recipientLabel = intent.tokenRecipient.slice(0, 6)
+  const recipientLabel = intent.tokenRecipient
+    ? intent.tokenRecipient.slice(0, 6)
+    : 'self'
 
   const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${intent.settlementLayers?.length ? ` via ${intent.settlementLayers.join()}` : ''}${intent.sponsored ? ' sponsored' : ''} to ${recipientLabel}`
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,13 @@ import {
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { fundAccount } from './funding.js'
-import type { Intent, ParsedToken, SourceAssets, TokenSymbol } from './types.js'
+import type {
+  Intent,
+  IntentResult,
+  ParsedToken,
+  SourceAssets,
+  TokenSymbol,
+} from './types.js'
 import { getChain, getChainById } from './utils/chains.js'
 import { getEnvironment } from './utils/environments.js'
 import { convertTokenAmount, getDecimals } from './utils/tokens.js'
@@ -159,7 +165,7 @@ export const processIntent = async (
   executionMode: string,
   existingAccount?: RhinestoneAccount,
   verbose?: boolean,
-) => {
+): Promise<IntentResult | undefined> => {
   const rhinestoneAccount =
     existingAccount ?? (await createRhinestoneAccount(environmentString))
 
@@ -458,7 +464,11 @@ export const processIntent = async (
       index: executionEndTime - fillTimestamp,
     })
 
-    console.dir(result, { depth: null })
+    if (verbose) {
+      console.dir(result, { depth: null })
+    }
+
+    return result as IntentResult
   } catch (error: any) {
     console.error(
       `${ts()} Bundle ${bundleLabel}: Submission/Execution failed`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,18 @@ export type BundleResult = {
   [key: string]: any
 }
 
+export type IntentResult = {
+  fill: {
+    hash: string | undefined
+    chainId: number
+  }
+  claims: {
+    hash: string | undefined
+    chainId: number
+  }[]
+  [key: string]: any
+}
+
 export type OrderPath = {
   [key: string]: any
 }

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -22,3 +22,36 @@ export const getEnvironment = (environmentString: string) => {
       throw new Error('Unknown environment')
   }
 }
+
+const DEPOSIT_SIGNER_ADDRESSES: Record<string, `0x${string}`> = {
+  prod: '0x177bfcdd15bc01e99013dcc5d2b09cd87a18ce9c',
+  dev: '0xd452930bf270723b2048c2ec9b65a336ea45b4f9',
+}
+
+const DEPOSIT_ORCHESTRATOR_URLS: Record<string, string> = {
+  prod: 'https://v1.orchestrator.rhinestone.dev',
+  dev: 'https://dev.v1.orchestrator.rhinestone.dev',
+}
+
+export const getDepositServiceConfig = (environmentString: string) => {
+  const orchestratorUrl = DEPOSIT_ORCHESTRATOR_URLS[environmentString]
+  if (!orchestratorUrl) {
+    throw new Error(
+      `Deposit mode not supported for environment '${environmentString}'`,
+    )
+  }
+
+  const signerAddress = DEPOSIT_SIGNER_ADDRESSES[environmentString]
+  if (!signerAddress) {
+    throw new Error(
+      `Deposit mode not supported for environment '${environmentString}': no signer address`,
+    )
+  }
+
+  return {
+    url: `${orchestratorUrl}/deposit-processor`,
+    apiKey: process.env.PROD_API_KEY!,
+    orchestratorUrl,
+    signerAddress,
+  }
+}

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -2,8 +2,7 @@ export const getEnvironment = (environmentString: string) => {
   switch (environmentString) {
     case 'prod':
       return {
-        url: undefined,
-        orchestratorUrl: 'https://v1.orchestrator.rhinestone.dev',
+        url: 'https://v1.orchestrator.rhinestone.dev',
         apiKey: process.env.PROD_API_KEY,
         useDevContracts: false,
         depositSignerAddress: '0x177bfcdd15bc01e99013dcc5d2b09cd87a18ce9c' as `0x${string}`,
@@ -11,7 +10,6 @@ export const getEnvironment = (environmentString: string) => {
     case 'dev':
       return {
         url: 'https://dev.v1.orchestrator.rhinestone.dev',
-        orchestratorUrl: 'https://dev.v1.orchestrator.rhinestone.dev',
         apiKey: process.env.DEV_API_KEY,
         useDevContracts: true,
         depositSignerAddress: '0xd452930bf270723b2048c2ec9b65a336ea45b4f9' as `0x${string}`,
@@ -19,7 +17,6 @@ export const getEnvironment = (environmentString: string) => {
     case 'local':
       return {
         url: 'http://localhost:3000',
-        orchestratorUrl: 'http://localhost:3000',
         apiKey: process.env.LOCAL_API_KEY,
         useDevContracts: true,
         depositSignerAddress: undefined,
@@ -39,9 +36,9 @@ export const getDepositServiceConfig = (environmentString: string) => {
   }
 
   return {
-    url: `${env.orchestratorUrl}/deposit-processor`,
+    url: `${env.url}/deposit-processor`,
     apiKey: process.env.PROD_API_KEY!,
-    orchestratorUrl: env.orchestratorUrl,
+    orchestratorUrl: env.url,
     signerAddress: env.depositSignerAddress,
   }
 }

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -3,55 +3,45 @@ export const getEnvironment = (environmentString: string) => {
     case 'prod':
       return {
         url: undefined,
+        orchestratorUrl: 'https://v1.orchestrator.rhinestone.dev',
         apiKey: process.env.PROD_API_KEY,
         useDevContracts: false,
+        depositSignerAddress: '0x177bfcdd15bc01e99013dcc5d2b09cd87a18ce9c' as `0x${string}`,
       }
     case 'dev':
       return {
         url: 'https://dev.v1.orchestrator.rhinestone.dev',
+        orchestratorUrl: 'https://dev.v1.orchestrator.rhinestone.dev',
         apiKey: process.env.DEV_API_KEY,
         useDevContracts: true,
+        depositSignerAddress: '0xd452930bf270723b2048c2ec9b65a336ea45b4f9' as `0x${string}`,
       }
     case 'local':
       return {
         url: 'http://localhost:3000',
+        orchestratorUrl: 'http://localhost:3000',
         apiKey: process.env.LOCAL_API_KEY,
         useDevContracts: true,
+        depositSignerAddress: undefined,
       }
     default:
       throw new Error('Unknown environment')
   }
 }
 
-const DEPOSIT_SIGNER_ADDRESSES: Record<string, `0x${string}`> = {
-  prod: '0x177bfcdd15bc01e99013dcc5d2b09cd87a18ce9c',
-  dev: '0xd452930bf270723b2048c2ec9b65a336ea45b4f9',
-}
-
-const DEPOSIT_ORCHESTRATOR_URLS: Record<string, string> = {
-  prod: 'https://v1.orchestrator.rhinestone.dev',
-  dev: 'https://dev.v1.orchestrator.rhinestone.dev',
-}
-
 export const getDepositServiceConfig = (environmentString: string) => {
-  const orchestratorUrl = DEPOSIT_ORCHESTRATOR_URLS[environmentString]
-  if (!orchestratorUrl) {
-    throw new Error(
-      `Deposit mode not supported for environment '${environmentString}'`,
-    )
-  }
+  const env = getEnvironment(environmentString)
 
-  const signerAddress = DEPOSIT_SIGNER_ADDRESSES[environmentString]
-  if (!signerAddress) {
+  if (!env.depositSignerAddress) {
     throw new Error(
       `Deposit mode not supported for environment '${environmentString}': no signer address`,
     )
   }
 
   return {
-    url: `${orchestratorUrl}/deposit-processor`,
+    url: `${env.orchestratorUrl}/deposit-processor`,
     apiKey: process.env.PROD_API_KEY!,
-    orchestratorUrl,
-    signerAddress,
+    orchestratorUrl: env.orchestratorUrl,
+    signerAddress: env.depositSignerAddress,
   }
 }


### PR DESCRIPTION
## Summary

Implements a new deposit execution mode that orchestrates cross-chain token delivery using the Rhinestone deposit service. The mode creates session-enabled accounts, registers with the deposit service, and polls for balance confirmation on the target chain.

## Changes

- **src/deposit.ts**: New file with complete deposit orchestration logic including account creation, service registration, and balance polling
- **src/cli.ts**: Added 'Deposit' option to execution mode menus
- **src/existing-intent.ts**: Added deposit mode routing with async support for multiple intents
- **src/main.ts**: Made verbose flag control result logging; added IntentResult type to processIntent return
- **src/types.ts**: Added IntentResult type definition
- **src/utils/environments.ts**: Added getDepositServiceConfig helper for environment-specific API endpoints and signer addresses