### PR TITLE
Add --account-type eoa support across all entry points

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -398,6 +398,23 @@ export const collectUserInput = async (): Promise<{
   }
 }
 
+export const parseAccountType = (): 'smart' | 'eoa' => {
+  const args = process.argv
+  const isAccountTypeSet = args.includes('--account-type')
+  const accountType = isAccountTypeSet
+    ? args[args.indexOf('--account-type') + 1]
+    : process.env.ACCOUNT_TYPE ?? 'smart'
+
+  if (accountType !== 'smart' && accountType !== 'eoa') {
+    console.error(
+      `Error: --account-type must be 'smart' or 'eoa', got '${accountType}'`,
+    )
+    process.exit(1)
+  }
+
+  return accountType as 'smart' | 'eoa'
+}
+
 export const showUserAccount = async (address: string) => {
   console.log(
     `To use your account, you'll need to fund it on the relevant source chain(s). Your account address is ${address}`,
@@ -412,7 +429,7 @@ export const getReplayParams = async () => {
   }
 
   const args = process.argv
-  const flagsWithValues = new Set(['--async', '--mode', '--env', '--feature-flags'])
+  const flagsWithValues = new Set(['--async', '--mode', '--env', '--feature-flags', '--account-type'])
   const slicedArgs = args.slice(2)
   const directFile = slicedArgs.find((arg, i) => {
     if (arg.startsWith('--')) return false
@@ -546,6 +563,8 @@ export const getReplayParams = async () => {
     ? args[args.indexOf('--feature-flags') + 1]
     : process.env.FEATURE_FLAGS
 
+  const accountType = parseAccountType()
+
   return {
     intents: parsedIntents,
     asyncMode,
@@ -554,5 +573,6 @@ export const getReplayParams = async () => {
     executionMode,
     verbose,
     featureFlags,
+    accountType,
   }
 }

--- a/src/existing-intent.ts
+++ b/src/existing-intent.ts
@@ -13,6 +13,7 @@ export const main = async () => {
   const rhinestoneAccount = await createRhinestoneAccount(
     replayParams.environment,
     replayParams.featureFlags,
+    replayParams.accountType,
   )
 
   if (replayParams.executionMode === 'deposit') {

--- a/src/get-address.ts
+++ b/src/get-address.ts
@@ -1,17 +1,11 @@
 import { select } from '@inquirer/prompts'
-import { RhinestoneSDK } from '@rhinestone/sdk'
 import { config } from 'dotenv'
-import type { Account, Hex } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
-import { getEnvironment } from './utils/environments.js'
+import { parseAccountType } from './cli.js'
+import { createRhinestoneAccount } from './main.js'
 
 config()
 
 export const main = async () => {
-  const owner: Account = privateKeyToAccount(
-    process.env.OWNER_PRIVATE_KEY! as Hex,
-  )
-
   const environmentString = await select({
     message: 'Select the environments to use',
     choices: [
@@ -30,25 +24,15 @@ export const main = async () => {
     ],
   })
 
-  const environment = getEnvironment(environmentString)
-  const orchestratorUrl = environment.url
-  const rhinestoneApiKey = environment.apiKey
-
-  // create the rhinestone account instance
-  const rhinestone = new RhinestoneSDK({
-    apiKey: rhinestoneApiKey,
-    endpointUrl: orchestratorUrl,
-    useDevContracts: environment.useDevContracts,
-  })
-  const rhinestoneAccount = await rhinestone.createAccount({
-    owners: {
-      type: 'ecdsa' as const,
-      accounts: [owner],
-    },
-  })
+  const accountType = parseAccountType()
+  const rhinestoneAccount = await createRhinestoneAccount(
+    environmentString,
+    undefined,
+    accountType,
+  )
 
   const address = await rhinestoneAccount.getAddress()
-  console.log(`Account address: ${address}`)
+  console.log(`Account address: ${address} (${accountType})`)
 }
 
 main()

--- a/src/get-balance.ts
+++ b/src/get-balance.ts
@@ -1,18 +1,13 @@
 import { select } from '@inquirer/prompts'
-import { RhinestoneSDK } from '@rhinestone/sdk'
 import { config } from 'dotenv'
-import { type Account, formatUnits, type Hex } from 'viem'
-import { privateKeyToAccount } from 'viem/accounts'
+import { formatUnits } from 'viem'
+import { parseAccountType } from './cli.js'
+import { createRhinestoneAccount } from './main.js'
 import { getChainById } from './utils/chains.js'
-import { getEnvironment } from './utils/environments.js'
 
 config()
 
 export const main = async () => {
-  const owner: Account = privateKeyToAccount(
-    process.env.OWNER_PRIVATE_KEY! as Hex,
-  )
-
   const environmentString = await select({
     message: 'Select the environments to use',
     choices: [
@@ -45,22 +40,12 @@ export const main = async () => {
     ],
   })
 
-  const environment = getEnvironment(environmentString)
-  const orchestratorUrl = environment.url
-  const rhinestoneApiKey = environment.apiKey
-
-  // create the rhinestone account instance
-  const rhinestone = new RhinestoneSDK({
-    apiKey: rhinestoneApiKey,
-    endpointUrl: orchestratorUrl,
-    useDevContracts: environment.useDevContracts,
-  })
-  const rhinestoneAccount = await rhinestone.createAccount({
-    owners: {
-      type: 'ecdsa' as const,
-      accounts: [owner],
-    },
-  })
+  const accountType = parseAccountType()
+  const rhinestoneAccount = await createRhinestoneAccount(
+    environmentString,
+    undefined,
+    accountType,
+  )
 
   const address = rhinestoneAccount.getAddress()
   console.log(`Account: ${address}\n`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,6 +142,7 @@ const extractFundingTokens = (sourceAssets: SourceAssets): string[] => {
 export const createRhinestoneAccount = async (
   environmentString: string,
   featureFlags?: string,
+  accountType: 'smart' | 'eoa' = 'smart',
 ) => {
   const owner = privateKeyToAccount(process.env.OWNER_PRIVATE_KEY! as Hex)
   const environment = getEnvironment(environmentString)
@@ -151,6 +152,16 @@ export const createRhinestoneAccount = async (
     useDevContracts: environment.useDevContracts,
     ...(featureFlags && { headers: { 'x-feature-flags': featureFlags } }),
   })
+
+  if (accountType === 'eoa') {
+    return rhinestone.createAccount({
+      eoa: owner,
+      account: {
+        type: 'eoa' as const,
+      },
+    })
+  }
+
   return rhinestone.createAccount({
     owners: {
       type: 'ecdsa' as const,

--- a/src/new-intent.ts
+++ b/src/new-intent.ts
@@ -3,7 +3,7 @@ import { config } from 'dotenv'
 config()
 
 import * as fs from 'node:fs'
-import { collectUserInput, showUserAccount } from './cli.js'
+import { collectUserInput, parseAccountType, showUserAccount } from './cli.js'
 import { createRhinestoneAccount, processIntent } from './main.js'
 
 export const main = async () => {
@@ -14,7 +14,12 @@ export const main = async () => {
     executionMode,
   } = await collectUserInput()
 
-  const rhinestoneAccount = await createRhinestoneAccount(environmentString)
+  const accountType = parseAccountType()
+  const rhinestoneAccount = await createRhinestoneAccount(
+    environmentString,
+    undefined,
+    accountType,
+  )
   const address = rhinestoneAccount.getAddress()
   await showUserAccount(address)
 


### PR DESCRIPTION
## Summary

- Adds `--account-type eoa` CLI flag (and `ACCOUNT_TYPE` env var fallback) to **all** bundle-generator entry points: `replay`, `new`, `address`, and `balance`
- Enables creating EOA-backed accounts instead of the default smart accounts, which is needed to reproduce and test EOA-specific orchestrator code paths (e.g. the destination swap metadata bug that only affects EOAs)

## Usage

```bash
# Via CLI flag — works with any command
pnpm replay destination-swap --mode simulate --env local --account-type eoa
pnpm address --account-type eoa
pnpm balance --account-type eoa

# Via env var
ACCOUNT_TYPE=eoa pnpm replay destination-swap --mode simulate --env local
```

## Changes

- **`src/cli.ts`** — adds shared `parseAccountType()` helper that reads from `--account-type` flag or `ACCOUNT_TYPE` env var (defaults to `smart`), used by `getReplayParams` and all other entry points
- **`src/main.ts`** — `createRhinestoneAccount` accepts optional `accountType` param; when `eoa`, uses `{ eoa: owner, account: { type: 'eoa' } }` matching the orchestrator-test pattern
- **`src/existing-intent.ts`** — threads `accountType` from replay params to account creation
- **`src/new-intent.ts`** — uses `parseAccountType()` to support EOA in the interactive flow
- **`src/get-address.ts`** — refactored to use `createRhinestoneAccount` + `parseAccountType()` (removes duplicated inline SDK setup)
- **`src/get-balance.ts`** — same refactor as get-address