### PR TITLE
fix: skip sponsorship fee check for tokenless intents

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -355,7 +355,10 @@ export const processIntent = async (
   }
 
   // check that sponsorship is working correctly
-  if (intent.sponsored) {
+  // Skip for tokenless intents — sponsor fee is legitimately zero because
+  // the relayer is compensated via the gas refund mechanism, not a user fee.
+  const isTokenless = intent.targetTokens.length === 0
+  if (intent.sponsored && !isTokenless) {
     // todo: adjust type in sdk
     const sponsorFee =
       // @ts-expect-error


### PR DESCRIPTION
## Summary

- Tokenless intents have `sponsorFee.relayer === 0` because the relayer is compensated via the gas refund mechanism, not a user-facing fee. The existing check assumed sponsored intents always have a non-zero relayer fee, which doesn't hold for tokenless plans.
- Skips the sponsorship validation when `targetTokens` is empty.