### PR TITLE
feat: update IntentResult to blanc operation model

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
-    "@rhinestone/sdk": "2.0.0-beta.2",
+    "@rhinestone/sdk": "2.0.0-beta.11",
     "abitype": "^1.0.8",
     "dotenv": "^16.5.0",
     "tsx": "^4.19.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.4.1
         version: 7.8.4(@types/node@22.18.1)
       '@rhinestone/sdk':
-        specifier: 2.0.0-beta.2
-        version: 2.0.0-beta.2(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+        specifier: 2.0.0-beta.11
+        version: 2.0.0-beta.11(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
       abitype:
         specifier: ^1.0.8
         version: 1.1.0(typescript@5.9.2)
@@ -64,24 +64,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.13':
     resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.13':
     resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.13':
     resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.13':
     resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
@@ -397,8 +401,8 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@rhinestone/sdk@2.0.0-beta.2':
-    resolution: {integrity: sha512-HvB3dXd1XOWCnfk/hRqBYOZ/CV8heo+g+0Fqr2Ij9jmHxIN2mxZxOeYx0NtpHUHQ/pldetvsgRU+oOYgFW8flw==}
+  '@rhinestone/sdk@2.0.0-beta.11':
+    resolution: {integrity: sha512-rMLNHY+gEidydjdlzV1VvenKrxdPxPVjEu2fhDuvA5LW0BW1GJ/0UI0WvMXSt4LuMQuy7caqsFy0Gf3FcZrixA==}
     peerDependencies:
       express: '>=4'
       jose: '>=5.0.0'
@@ -409,8 +413,8 @@ packages:
       jose:
         optional: true
 
-  '@rhinestone/shared-configs@1.4.139':
-    resolution: {integrity: sha512-ogN9gBu76BcmYMSZ5oymPonUsPDi6uT+EG6kxQt7h94jSNcpuA1WeKZq3AipJEMjVUl48Fpa4ubwhFk8mRw+Ig==}
+  '@rhinestone/shared-configs@1.5.1':
+    resolution: {integrity: sha512-RtbhW8oQPZeipov1NF3pd4tXvR+C5cac7yhYC0pd2aoE3iBb53U256yvmfyAJ9/s9E0UauT1sNFC/LrLJC+uvA==}
     peerDependencies:
       typescript: ^5
       viem: ^2.40.1
@@ -841,15 +845,15 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@rhinestone/sdk@2.0.0-beta.2(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/sdk@2.0.0-beta.11(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
     dependencies:
-      '@rhinestone/shared-configs': 1.4.139(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+      '@rhinestone/shared-configs': 1.5.1(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
       solady: 0.1.26
       viem: 2.45.0(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
-  '@rhinestone/shared-configs@1.4.139(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/shared-configs@1.5.1(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
     dependencies:
       typescript: 5.9.2
       viem: 2.45.0(typescript@5.9.2)

--- a/src/main.ts
+++ b/src/main.ts
@@ -502,7 +502,7 @@ export const processIntent = async (
         const txReceipt = await publicClient.getTransactionReceipt({
           hash: op.hash as Hex,
         })
-        ;(op as any).gasUsed = txReceipt.gasUsed
+        op.gasUsed = txReceipt.gasUsed
         // Use the latest on-chain timestamp as the fill timestamp
         const block = await publicClient.getBlock({
           blockNumber: txReceipt.blockNumber,

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,12 @@ import {
 } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import { fundAccount } from './funding.js'
-import type {
-  Intent,
-  IntentResult,
-  ParsedToken,
-  SourceAssets,
+import {
+  getAllOperations,
+  type Intent,
+  type IntentResult,
+  type ParsedToken,
+  type SourceAssets,
 } from './types.js'
 import { getChain, getChainById } from './utils/chains.js'
 import { getEnvironment } from './utils/environments.js'
@@ -486,35 +487,30 @@ export const processIntent = async (
     const executionStartTime = Date.now()
     const result = (await rhinestoneAccount.waitForExecution(
       transactionResult,
-    )) as any
+    )) as IntentResult
     const executionEndTime = Date.now()
 
     result.label = bundleLabel
+    const allOps = getAllOperations(result)
     let fillTimestamp = executionEndTime
-    if (!isSimulate && result.fill.hash) {
-      const fillPublicClient = createPublicClient({
-        chain: getChainById(result.fill.chainId),
-        transport: http(),
-      })
-      const fillTx = await fillPublicClient.getTransactionReceipt({
-        hash: result.fill.hash as Hex,
-      })
-      const fillBlock = await fillPublicClient.getBlock({
-        blockNumber: fillTx.blockNumber,
-      })
-      fillTimestamp = Number(fillBlock.timestamp) * 1000
-      result.fill.gasUsed = fillTx.gasUsed
-    }
-    for (const claim of result.claims) {
-      if (claim.hash) {
-        const claimPublicClient = createPublicClient({
-          chain: getChainById(claim.chainId),
+    for (const op of allOps) {
+      if (!isSimulate && op.hash) {
+        const publicClient = createPublicClient({
+          chain: getChainById(op.chainId),
           transport: http(),
         })
-        const claimTx = await claimPublicClient.getTransactionReceipt({
-          hash: claim.hash as Hex,
+        const txReceipt = await publicClient.getTransactionReceipt({
+          hash: op.hash as Hex,
         })
-        claim.gasUsed = claimTx.gasUsed
+        ;(op as any).gasUsed = txReceipt.gasUsed
+        // Use the latest on-chain timestamp as the fill timestamp
+        const block = await publicClient.getBlock({
+          blockNumber: txReceipt.blockNumber,
+        })
+        const blockTime = Number(block.timestamp) * 1000
+        if (blockTime > fillTimestamp) {
+          fillTimestamp = blockTime
+        }
       }
     }
 
@@ -539,7 +535,7 @@ export const processIntent = async (
       console.dir(result, { depth: null })
     }
 
-    return result as IntentResult
+    return result
   } catch (error: any) {
     console.error(
       `${ts()} Bundle ${bundleLabel}: Submission/Execution failed`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,16 +39,32 @@ export type Intent = {
 
 export type TokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT'
 
+/** Matches the blanc API response shape from the orchestrator / SDK. */
 export type IntentResult = {
-  fill: {
-    hash: string | undefined
-    chainId: number
-  }
-  claims: {
-    hash: string | undefined
-    chainId: number
+  status: string
+  accountAddress: string
+  operations: {
+    chain: number
+    items: {
+      status: string
+      failureReason?: string
+      txHash?: string
+      timestamp?: number
+    }[]
   }[]
+  label?: string
   [key: string]: any
+}
+
+/** Flatten all operations from an IntentResult into a list with chainId. */
+export function getAllOperations(result: IntentResult) {
+  return result.operations.flatMap((chainOps) =>
+    chainOps.items.map((item) => ({
+      hash: item.txHash,
+      chainId: chainOps.chain,
+      item,
+    })),
+  )
 }
 
 export type OrderPath = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,12 +45,10 @@ export type IntentResult = {
   accountAddress: string
   operations: {
     chain: number
-    items: {
-      status: string
-      failureReason?: string
-      txHash?: string
-      timestamp?: number
-    }[]
+    status: string
+    failureReason?: string
+    txHash?: string
+    timestamp?: number
   }[]
   label?: string
   [key: string]: any
@@ -58,13 +56,12 @@ export type IntentResult = {
 
 /** Flatten all operations from an IntentResult into a list with chainId. */
 export function getAllOperations(result: IntentResult) {
-  return result.operations.flatMap((chainOps) =>
-    chainOps.items.map((item) => ({
-      hash: item.txHash,
-      chainId: chainOps.chain,
-      item,
-    })),
-  )
+  return result.operations.map((operation) => ({
+    hash: operation.txHash,
+    chainId: operation.chain,
+    operation,
+    gasUsed: undefined as bigint | undefined,
+  }))
 }
 
 export type OrderPath = {


### PR DESCRIPTION
## Summary

Updates bundle-generator to consume the blanc operation status shape from the SDK/orchestrator.

- `IntentResult` now models `status`, `accountAddress`, and per-chain `operations[]`
- `getAllOperations()` replaces direct legacy `.fill` / `.claims` access
- Operation handling no longer depends on public operation types; it iterates per-chain status entries and uses `txHash` when present
- Keeps compatibility with the SDK's flat `ChainOperation[]` response shape

### Related PRs

- **orchestrator**: https://github.com/rhinestonewtf/orchestrator/pull/1447
- **SDK**: https://github.com/rhinestonewtf/sdk/pull/446