### PR TITLE
[RHI-3934] Non-EVM destinations + drop legacy feature-flags (stacked on #50)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -410,7 +410,6 @@ export const getReplayParams = async () => {
     '--async',
     '--mode',
     '--env',
-    '--feature-flags',
     '--account-type',
     '--quote',
   ])
@@ -541,11 +540,6 @@ export const getReplayParams = async () => {
 
   const verbose = args.includes('--verbose')
 
-  const isFeatureFlagsSet = args.includes('--feature-flags')
-  const featureFlags = isFeatureFlagsSet
-    ? args[args.indexOf('--feature-flags') + 1]
-    : process.env.FEATURE_FLAGS
-
   const accountType = parseAccountType()
 
   const isQuoteSet = args.includes('--quote')
@@ -567,7 +561,6 @@ export const getReplayParams = async () => {
     environment,
     executionMode,
     verbose,
-    featureFlags,
     accountType,
     quoteSelection,
   }

--- a/src/existing-intent.ts
+++ b/src/existing-intent.ts
@@ -11,7 +11,6 @@ export const main = async () => {
 
   const rhinestoneAccount = await createRhinestoneAccount(
     replayParams.environment,
-    replayParams.featureFlags,
     replayParams.accountType,
   )
 

--- a/src/funding.ts
+++ b/src/funding.ts
@@ -12,7 +12,7 @@ import {
 } from 'viem'
 import { arbitrum, base, mainnet } from 'viem/chains'
 import type { SourceTokens } from './types.js'
-import { getChain } from './utils/chains.js'
+import { getEvmChain } from './utils/chains.js'
 
 // Hardcoded address + balance slot table for local-testnet funding only.
 // LOCAL_TESTNET=true reaches here; nothing else needs these. Add chains/tokens
@@ -71,7 +71,7 @@ const findEntryByAddress = (chainId: number, tokenAddress: Address) => {
 
 async function handleSourceTokensWithSymbols(
   account: Address,
-  chain: ReturnType<typeof getChain>,
+  chain: Chain,
   testClient: ReturnType<typeof createTestClient>,
   sourceToken: string,
 ) {
@@ -102,7 +102,7 @@ async function handleSourceTokensWithSymbols(
 
 async function handleSourceTokensWithAmount(
   account: Address,
-  chain: ReturnType<typeof getChain>,
+  chain: Chain,
   testClient: ReturnType<typeof createTestClient>,
   sourceToken: { chain: { id: number }; address: string; amount?: string },
 ) {
@@ -149,7 +149,7 @@ export const fundAccount = async ({
   if (process.env.LOCAL_TESTNET?.toString() !== 'true') return
 
   for (const sourceChain of sourceChains) {
-    const chain = getChain(sourceChain)
+    const chain = getEvmChain(sourceChain)
     console.log('Funding on %s for %s', chain.name, account)
     const testClient = createTestClient({
       chain,

--- a/src/get-address.ts
+++ b/src/get-address.ts
@@ -27,7 +27,6 @@ export const main = async () => {
   const accountType = parseAccountType()
   const rhinestoneAccount = await createRhinestoneAccount(
     environmentString,
-    undefined,
     accountType,
   )
 

--- a/src/get-balance.ts
+++ b/src/get-balance.ts
@@ -43,7 +43,6 @@ export const main = async () => {
   const accountType = parseAccountType()
   const rhinestoneAccount = await createRhinestoneAccount(
     environmentString,
-    undefined,
     accountType,
   )
 
@@ -60,9 +59,8 @@ export const main = async () => {
     portfolio.forEach((token) => {
       console.log(`   ${token.symbol}: (${token.chains.length} chain(s))`)
       token.chains.forEach((chain) => {
-        const chainBalance = chain.locked + chain.unlocked
-        if (chainBalance === 0n) return
-        const chainFormatted = formatUnits(chainBalance, chain.decimals)
+        if (chain.amount === 0n) return
+        const chainFormatted = formatUnits(chain.amount, chain.decimals)
         const chainInfo = getChainById(chain.chain)
         const chainName = chainInfo?.name || `Chain ${chain.chain}`
         console.log(`     └─ ${chainName}: ${chainFormatted}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import {
   type AuxiliaryFunds,
   type PreparedQuotes,
   RhinestoneSDK,
+  type Transaction,
 } from '@rhinestone/sdk'
 import {
   type Address,
@@ -24,7 +25,12 @@ import {
   type ParsedToken,
   type SourceAssets,
 } from './types.js'
-import { getChain, getChainById } from './utils/chains.js'
+import {
+  getChain,
+  getChainById,
+  getEvmChain,
+  isNonEvmChain,
+} from './utils/chains.js'
 import { getEnvironment } from './utils/environments.js'
 import { convertTokenAmount, getDecimals } from './utils/tokens.js'
 
@@ -144,7 +150,6 @@ const extractFundingTokens = (sourceAssets: SourceAssets): string[] => {
 
 export const createRhinestoneAccount = async (
   environmentString: string,
-  featureFlags?: string,
   accountType: 'smart' | 'eoa' = 'smart',
 ) => {
   const owner = privateKeyToAccount(process.env.OWNER_PRIVATE_KEY! as Hex)
@@ -153,7 +158,6 @@ export const createRhinestoneAccount = async (
     apiKey: environment.apiKey,
     endpointUrl: environment.url,
     useDevContracts: environment.useDevContracts,
-    ...(featureFlags && { headers: { 'x-feature-flags': featureFlags } }),
   })
 
   if (accountType === 'eoa') {
@@ -233,7 +237,7 @@ export const processIntent = async (
   const targetChain = getChain(intent.targetChain)
   const sourceChains =
     intent.sourceChains.length > 0
-      ? intent.sourceChains.map((chain) => getChain(chain))
+      ? intent.sourceChains.map((chain) => getEvmChain(chain))
       : []
 
   // fund the account
@@ -388,8 +392,13 @@ export const processIntent = async (
       : {}),
   }
 
-  const preparedTransaction =
-    await rhinestoneAccount.prepareTransaction(transactionDetails)
+  // SDK's `Transaction` is a discriminated union (SameChain | CrossChainEvm |
+  // CrossChainNonEvm) keyed on the `targetChain` / `tokenRequests` shape.
+  // The intent JSON we read is permissive and chain-agnostic, so we build a
+  // single shape and let the SDK route it at runtime.
+  const preparedTransaction = await rhinestoneAccount.prepareTransaction(
+    transactionDetails as Transaction,
+  )
 
   const prepareEndTime = Date.now()
   console.log(
@@ -494,7 +503,9 @@ export const processIntent = async (
     const allOps = getAllOperations(result)
     let fillTimestamp = executionEndTime
     for (const op of allOps) {
-      if (!isSimulate && op.hash) {
+      // Non-EVM chains have no viem RPC — skip receipt enrichment there.
+      // Bundle status tracking for non-EVM dests is tracked separately (RHI-3797).
+      if (!isSimulate && op.hash && !isNonEvmChain(op.chainId)) {
         const publicClient = createPublicClient({
           chain: getChainById(op.chainId),
           transport: http(),
@@ -541,5 +552,9 @@ export const processIntent = async (
       `${ts()} Bundle ${bundleLabel}: Submission/Execution failed`,
       error?.response?.data ?? error,
     )
+    if (error?.issues) {
+      console.error(`${ts()} Bundle ${bundleLabel}: issues:`)
+      console.dir(error.issues, { depth: null })
+    }
   }
 }

--- a/src/new-intent.ts
+++ b/src/new-intent.ts
@@ -17,7 +17,6 @@ export const main = async () => {
   const accountType = parseAccountType()
   const rhinestoneAccount = await createRhinestoneAccount(
     environmentString,
-    undefined,
     accountType,
   )
   const address = rhinestoneAccount.getAddress()

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -1,23 +1,67 @@
+import { type NonEvmChain, solanaMainnet, tronMainnet } from '@rhinestone/sdk'
+import type { Chain } from 'viem'
 import * as viemChains from 'viem/chains'
 
-export const getChain = (name: string) => {
+// Non-EVM destination chains — name-keyed so intent JSON can reference them
+// the same way as viem chain names. The SDK intentionally doesn't expose a
+// numeric `id` on `NonEvmChain` (it derives one internally from `caip2`),
+// but simulation-tests reads `targetChain.id` everywhere downstream — so we
+// shim a constant id here. Values must match the orchestrator's synthetic
+// id registry (`fromCaip2` in @rhinestone/sdk/dist/.../caip2.js).
+type DestinationChainWithId = NonEvmChain & { id: number }
+
+export const NON_EVM_CHAINS: Record<string, DestinationChainWithId> = {
+  solana: { ...solanaMainnet, id: 792703809 },
+  tron: { ...tronMainnet, id: 728126428 },
+}
+
+export const NON_EVM_CHAIN_IDS: ReadonlySet<number> = new Set(
+  Object.values(NON_EVM_CHAINS).map((c) => c.id),
+)
+
+export const isNonEvmChain = (chainId: number): boolean =>
+  NON_EVM_CHAIN_IDS.has(chainId)
+
+// viem re-exports some non-Chain values (e.g. defineChain). Guard the
+// .name / .id access so the find() doesn't throw on those.
+const isViemChain = (value: unknown): value is Chain => {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as { id?: unknown; name?: unknown }
+  return typeof v.id === 'number' && typeof v.name === 'string'
+}
+
+export const getChain = (name: string): Chain | DestinationChainWithId => {
+  const lower = name.toLowerCase()
+  const nonEvm = NON_EVM_CHAINS[lower]
+  if (nonEvm) return nonEvm
   const chain = Object.values(viemChains).find(
-    (chain) =>
-      (chain.name as string).replace(/ /g, '').toLowerCase() ===
-      name.toLowerCase(),
+    (c) => isViemChain(c) && c.name.replace(/ /g, '').toLowerCase() === lower,
   )
   if (!chain) {
     throw new Error(
       `Chain ${name} is not supported. Use the viem chain name without spaces.`,
     )
   }
-  return chain
+  return chain as Chain
 }
 
-export const getChainById = (chainId: number) => {
-  const chain = Object.values(viemChains).find((chain) => chain.id === chainId)
+// EVM-only resolver. Use this on paths that can't handle non-EVM chains
+// (anvil funding, source-chain lists for cross-chain EVM transactions, etc.).
+export const getEvmChain = (name: string): Chain => {
+  if (NON_EVM_CHAINS[name.toLowerCase()]) {
+    throw new Error(
+      `Chain ${name} is non-EVM and not supported in this context.`,
+    )
+  }
+  return getChain(name) as Chain
+}
+
+export const getChainById = (chainId: number): Chain => {
+  const chain = Object.values(viemChains).find(
+    (c) => isViemChain(c) && c.id === chainId,
+  )
   if (!chain) {
     throw new Error(`Chain with id ${chainId} is not supported.`)
   }
-  return chain
+  return chain as Chain
 }

--- a/src/utils/environments.ts
+++ b/src/utils/environments.ts
@@ -1,21 +1,37 @@
-export const getEnvironment = (environmentString: string) => {
+type Environment = {
+  url: string
+  apiKey: string
+  useDevContracts: boolean
+}
+
+const readApiKey = (envVar: string, environment: string): string => {
+  const value = process.env[envVar]
+  if (!value) {
+    throw new Error(
+      `${envVar} is required for the '${environment}' environment.`,
+    )
+  }
+  return value
+}
+
+export const getEnvironment = (environmentString: string): Environment => {
   switch (environmentString) {
     case 'prod':
       return {
         url: 'https://v1.orchestrator.rhinestone.dev',
-        apiKey: process.env.PROD_API_KEY,
+        apiKey: readApiKey('PROD_API_KEY', 'prod'),
         useDevContracts: false,
       }
     case 'dev':
       return {
         url: 'https://dev.v1.orchestrator.rhinestone.dev',
-        apiKey: process.env.DEV_API_KEY,
+        apiKey: readApiKey('DEV_API_KEY', 'dev'),
         useDevContracts: true,
       }
     case 'local':
       return {
         url: 'http://localhost:3000',
-        apiKey: process.env.LOCAL_API_KEY,
+        apiKey: readApiKey('LOCAL_API_KEY', 'local'),
         useDevContracts: true,
       }
     default:

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -7,7 +7,7 @@ import {
   parseUnits,
 } from 'viem'
 import type { Token } from '../types.js'
-import { getChainById } from './chains.js'
+import { getChainById, NON_EVM_CHAINS } from './chains.js'
 
 const KNOWN_DECIMALS: Record<string, number> = {
   ETH: 18,
@@ -15,6 +15,35 @@ const KNOWN_DECIMALS: Record<string, number> = {
   USDC: 6,
   USDT: 6,
 }
+
+// Non-EVM token decimals — keyed by NON_EVM_CHAINS key, then mint/contract
+// address. SPL mints (base58) and Tron T-prefix addresses can't be queried
+// via viem, so we hardcode the handful we use in test intents. Case-sensitive
+// — the orchestrator and SDK both treat these as opaque strings.
+const NON_EVM_TOKEN_DECIMALS_BY_NAME: Record<string, Record<string, number>> = {
+  solana: {
+    EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v: 6, // USDC
+    Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB: 6, // USDT
+  },
+  tron: {
+    TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t: 6, // USDT
+  },
+}
+
+const NON_EVM_TOKEN_DECIMALS: Record<
+  number,
+  Record<string, number>
+> = Object.fromEntries(
+  Object.entries(NON_EVM_TOKEN_DECIMALS_BY_NAME).map(([name, tokens]) => {
+    const chain = NON_EVM_CHAINS[name]
+    if (!chain) {
+      throw new Error(
+        `NON_EVM_TOKEN_DECIMALS references unknown chain '${name}'`,
+      )
+    }
+    return [chain.id, tokens]
+  }),
+)
 
 const decimalsCache = new Map<string, number>()
 
@@ -25,6 +54,19 @@ export const getDecimals = async ({
   tokenSymbolOrAddress: string
   chainId: number
 }): Promise<number> => {
+  // Non-EVM destinations: look up by mint/contract address in the static
+  // table. No EVM RPC available for these chains.
+  const nonEvmTable = NON_EVM_TOKEN_DECIMALS[chainId]
+  if (nonEvmTable) {
+    const knownNonEvm = nonEvmTable[tokenSymbolOrAddress]
+    if (knownNonEvm !== undefined) return knownNonEvm
+    const knownSymbol = KNOWN_DECIMALS[tokenSymbolOrAddress.toUpperCase()]
+    if (knownSymbol !== undefined) return knownSymbol
+    throw new Error(
+      `Unknown non-EVM token '${tokenSymbolOrAddress}' on chain ${chainId}. ` +
+        `Known: ${Object.keys(nonEvmTable).join(', ')} or symbols ${Object.keys(KNOWN_DECIMALS).join(', ')}.`,
+    )
+  }
   if (!isAddress(tokenSymbolOrAddress)) {
     const known = KNOWN_DECIMALS[tokenSymbolOrAddress.toUpperCase()]
     if (known !== undefined) return known


### PR DESCRIPTION
> **Stacked on #50** — review that first; will auto-retarget to `main` when #50 merges.

## Summary
Builds on top of #50's `IntentResult` reshape + SDK 2.0.0-beta.11 bump. This PR adds only the simulation-tests-specific changes:

- **Non-EVM destinations** (Solana / Tron): name-keyed `NON_EVM_CHAINS` registry in `src/utils/chains.ts`, derived `isNonEvmChain` / `getEvmChain` helpers, SPL/Tron decimals fallback in `tokens.ts`. Receipt enrichment in #50's per-operation loop now skips non-EVM chains (bundle-status indexing for non-EVM dests is tracked separately in RHI-3797).
- **Drop legacy `--feature-flags`** plumbing (CLI arg, `FEATURE_FLAGS` env, `x-feature-flags` SDK header forwarding) — anticipating [orchestrator PR #1517](https://github.com/rhinestonewtf/orchestrator/pull/1517) which removes the header from the route schema and deletes the legacy pipeline middleware.
- **Hardening**: validate `apiKey` in `getEnvironment` so the SDK config gets a `string` (not `string | undefined`); narrow `Transaction` at the `prepareTransaction` call site; update `get-balance.ts` for SDK v2's `Portfolio` shape (`amount` replaces `locked + unlocked`).

Closes RHI-3934

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check src/` — clean (11 pre-existing warnings unchanged)
- [ ] Smoke: run an existing EVM intent end-to-end on dev (`pnpm new-intent --env dev`)
- [ ] Smoke: run a Solana-destination intent end-to-end on dev
- [ ] Smoke: `pnpm get-balance` against an account with mainnet portfolio holdings

🤖 Generated with [Claude Code](https://claude.com/claude-code)