### PR TITLE
[RHI-3948] Adopt SDK SettlementLayerFilter shape and validate intent JSONs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,22 +1,86 @@
 import * as fs from 'node:fs'
 import path from 'node:path'
 import { checkbox, confirm, input, select } from '@inquirer/prompts'
+import type { SettlementLayer } from '@rhinestone/sdk'
 import { type Address, type Chain, type Hex, isAddress, parseUnits } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import * as viemChains from 'viem/chains'
 import type { Intent } from './types.js'
 import { getDecimals } from './utils/tokens.js'
 
+// Mirrors the SDK's internal cross-chain layer list, which isn't exported as a
+// runtime value. Keep in sync with @rhinestone/sdk's KNOWN_SETTLEMENT_LAYERS.
+const KNOWN_SETTLEMENT_LAYERS = [
+  'ACROSS',
+  'ECO',
+  'RELAY',
+  'OFT',
+  'NEAR',
+  'RHINO',
+  'CCTP',
+] as const satisfies readonly SettlementLayer[]
+
+const isKnownSettlementLayer = (v: unknown): v is SettlementLayer =>
+  typeof v === 'string' &&
+  (KNOWN_SETTLEMENT_LAYERS as readonly string[]).includes(v)
+
+// A raw array of layer names is the historical (buggy) shape: the SDK silently
+// treats it as `{ exclude: undefined }` and matches all layers. Reject it so the
+// trap can't be reintroduced.
+const validateSettlementLayers = (raw: unknown, context: string): void => {
+  if (raw === undefined) return
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    throw new Error(
+      `${context}: invalid \`settlementLayers\` shape — expected \`{ "include": [...] }\` or \`{ "exclude": [...] }\` (or omit the field), got ${JSON.stringify(raw)}.`,
+    )
+  }
+  const hasInclude = 'include' in raw
+  const hasExclude = 'exclude' in raw
+  if (hasInclude === hasExclude) {
+    throw new Error(
+      `${context}: \`settlementLayers\` must specify exactly one of \`include\` or \`exclude\`.`,
+    )
+  }
+  const key = hasInclude ? 'include' : 'exclude'
+  const values = (raw as Record<string, unknown>)[key]
+  if (!Array.isArray(values) || values.length === 0) {
+    throw new Error(
+      `${context}: \`settlementLayers.${key}\` must be a non-empty array.`,
+    )
+  }
+  for (const v of values) {
+    if (!isKnownSettlementLayer(v)) {
+      throw new Error(
+        `${context}: unknown settlement layer \`${String(v)}\` in \`settlementLayers.${key}\`. Known: ${KNOWN_SETTLEMENT_LAYERS.join(', ')}.`,
+      )
+    }
+  }
+}
+
+const validateIntent = (intent: unknown, context: string): void => {
+  if (!intent || typeof intent !== 'object') {
+    throw new Error(`${context}: intent must be an object.`)
+  }
+  validateSettlementLayers(
+    (intent as { settlementLayers?: unknown }).settlementLayers,
+    context,
+  )
+}
+
 const readIntentFile = (filePath: string) => {
   try {
     const data = fs.readFileSync(filePath, 'utf-8')
-    return JSON.parse(data)
+    const parsed = JSON.parse(data)
+    const intents: unknown[] = parsed?.intentList ?? [parsed]
+    for (let i = 0; i < intents.length; i++) {
+      validateIntent(intents[i], `${filePath}[${i}]`)
+    }
+    return parsed
   } catch (error) {
-    const message =
-      error instanceof SyntaxError
-        ? `Invalid JSON in ${filePath}: ${error.message}`
-        : `Failed to read ${filePath}: ${error}`
-    throw new Error(message)
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid JSON in ${filePath}: ${error.message}`)
+    }
+    throw error
   }
 }
 
@@ -64,6 +128,7 @@ export const collectUserInput = async (): Promise<{
       { name: 'WETH', value: 'WETH' },
       { name: 'USDC', value: 'USDC' },
       { name: 'USDT', value: 'USDT' },
+      { name: 'USDT0', value: 'USDT0' },
       { name: 'Arbitrary token', value: 'Arbitrary token' },
     ],
     validate: (choices) => {
@@ -116,6 +181,7 @@ export const collectUserInput = async (): Promise<{
       { name: 'WETH', value: 'WETH' },
       { name: 'USDC', value: 'USDC' },
       { name: 'USDT', value: 'USDT' },
+      { name: 'USDT0', value: 'USDT0' },
       { name: 'Arbitrary token', value: 'Arbitrary token' },
     ],
     validate: (choices) => {
@@ -183,6 +249,7 @@ export const collectUserInput = async (): Promise<{
             { name: 'WETH', value: 'WETH' },
             { name: 'USDC', value: 'USDC' },
             { name: 'USDT', value: 'USDT' },
+            { name: 'USDT0', value: 'USDT0' },
           ],
         })
         if (tokensForChain.length > 0) {
@@ -365,7 +432,13 @@ export const collectUserInput = async (): Promise<{
       ...(sourceAssetsConfig ? { sourceAssets: sourceAssetsConfig } : {}),
       tokenRecipient,
       ...(recipient ? { recipient } : {}),
-      settlementLayers,
+      ...(settlementLayers.length > 0
+        ? {
+            settlementLayers: {
+              include: settlementLayers as SettlementLayer[],
+            },
+          }
+        : {}),
       sponsored,
       ...(feeAsset ? { feeAsset } : {}),
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -355,7 +355,12 @@ export const processIntent = async (
     ? intent.tokenRecipient.slice(0, 6)
     : 'self'
 
-  const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${intent.settlementLayers?.length ? ` via ${intent.settlementLayers.join()}` : ''}${intent.sponsored ? ' sponsored' : ''} to ${recipientLabel}`
+  const settlementLayersLabel = intent.settlementLayers
+    ? 'include' in intent.settlementLayers
+      ? ` via ${intent.settlementLayers.include.join()}`
+      : ` excluding ${intent.settlementLayers.exclude.join()}`
+    : ''
+  const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${settlementLayersLabel}${intent.sponsored ? ' sponsored' : ''} to ${recipientLabel}`
 
   console.log(`${ts()} Bundle ${bundleLabel}: Starting transaction process`)
 
@@ -382,7 +387,7 @@ export const processIntent = async (
     tokenRequests,
     sponsored: intent.sponsored,
     ...(resolvedSourceAssets ? { sourceAssets: resolvedSourceAssets } : {}),
-    ...(intent.settlementLayers?.length > 0
+    ...(intent.settlementLayers
       ? { settlementLayers: intent.settlementLayers }
       : {}),
     ...(intent.recipient ? { recipient: intent.recipient as Address } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { SettlementLayerFilter } from '@rhinestone/sdk'
 import type { Address } from 'abitype'
 
 export type Token = {
@@ -30,14 +31,14 @@ export type Intent = {
   sourceAssets?: SourceAssets
   tokenRecipient: string
   recipient?: string
-  settlementLayers: string[]
+  settlementLayers?: SettlementLayerFilter
   sponsored: boolean
   destinationOps?: boolean
   feeAsset?: string
   auxiliaryFunds?: Record<string, Record<string, string>>
 }
 
-export type TokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT'
+export type TokenSymbol = 'ETH' | 'WETH' | 'USDC' | 'USDT' | 'USDT0'
 
 /** Matches the blanc API response shape from the orchestrator / SDK. */
 export type IntentResult = {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -14,6 +14,7 @@ const KNOWN_DECIMALS: Record<string, number> = {
   WETH: 18,
   USDC: 6,
   USDT: 6,
+  USDT0: 6,
 }
 
 // Non-EVM token decimals — keyed by NON_EVM_CHAINS key, then mint/contract


### PR DESCRIPTION
## Summary

- The SDK's `SettlementLayerFilter` is `{ include: [...] } | { exclude: [...] }`. Its `encodeSettlementLayers` helper silently treats a bare array as `{ exclude: undefined }` — which returns the full set of known layers. So passing `settlementLayers: ["RHINO"]` from JSON resulted in quotes from every layer instead of just RHINO.
- Typed `Intent.settlementLayers` as `SettlementLayerFilter` (optional) and added a load-time validator that rejects bare arrays, empty include/exclude, both-or-neither keys, and unknown layer names — pointing at file path + intent index. Wrong shapes now fail fast instead of degrading to "no filter".
- Interactive CLI emits the object form; `main.ts` forwards the filter verbatim and labels both `include` and `exclude` in bundle logs. USDT0 added to `KNOWN_DECIMALS`, `TokenSymbol`, and the interactive token pickers so Plasma USDT0 routes work end-to-end.

Closes RHI-3948 — related: RHI-3869 (SDK side).

## Test plan

- [x] `pnpm replay across --env prod --mode simulate` — returns a single RHINO route (was: ACROSS/ECO/RHINO mix); bundle ran to COMPLETED on Base + Plasma.
- [x] `npx tsc --noEmit` clean; `npx biome check src/` no new errors.
- [ ] Smoke check: load an intent with `settlementLayers: ["RHINO"]` (old shape) — expect a thrown validator error naming the file and index.
- [ ] Smoke check: load an intent with `settlementLayers: { include: [], exclude: [] }` — expect "must specify exactly one of include or exclude".
- [ ] Smoke check: load an intent with `settlementLayers: { include: ["BOGUS"] }` — expect "unknown settlement layer BOGUS".
- [ ] Verify other intents (no `settlementLayers` field) still route normally (e.g. `pnpm replay usdc-arb-base --env prod --mode simulate`).

## Notes

- `intents/*.json` files are gitignored so the JSON shape migrations aren't in the diff. Anyone with old intent files locally will hit the validator on next replay — the error message tells them exactly how to fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)