### PR TITLE
Support non-interactive --env/--network flags for balance and address

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,36 @@ Set the API key for your target environment in `.env`. The owner private key is 
 
 ## Commands
 
-### `pnpm address`
+### `pnpm address [options]`
 
 Prints the smart account address.
 
-### `pnpm balance`
+| Option | Description |
+|---|---|
+| `--env <prod\|dev\|local>` | Set environment (prompts if omitted) |
+| `--account-type <smart\|eoa>` | Set account type (defaults to `smart`) |
+
+```sh
+pnpm address                                  # interactive
+pnpm address --env prod                        # non-interactive
+pnpm address --env dev --account-type eoa
+```
+
+### `pnpm balance [options]`
 
 Shows token balances across all supported chains.
+
+| Option | Description |
+|---|---|
+| `--env <prod\|dev\|local>` | Set environment (prompts if omitted) |
+| `--network <mainnet\|testnet>` | Set network type (prompts if omitted) |
+| `--account-type <smart\|eoa>` | Set account type (defaults to `smart`) |
+
+```sh
+pnpm balance                                       # interactive
+pnpm balance --env prod --network mainnet           # non-interactive
+pnpm balance --env dev --network testnet --account-type eoa
+```
 
 ### `pnpm new`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -465,6 +465,78 @@ export const parseAccountType = (): 'smart' | 'eoa' => {
   return accountType as 'smart' | 'eoa'
 }
 
+const VALID_ENVIRONMENTS = ['prod', 'dev', 'local'] as const
+type EnvironmentValue = (typeof VALID_ENVIRONMENTS)[number]
+
+const isEnvironmentValue = (v: string): v is EnvironmentValue =>
+  (VALID_ENVIRONMENTS as readonly string[]).includes(v)
+
+const getFlagValue = (flag: string): string | undefined => {
+  const args = process.argv
+  const idx = args.indexOf(flag)
+  if (idx === -1) return undefined
+  return args[idx + 1]
+}
+
+/**
+ * Resolve the target environment from the `--env` flag, falling back to an
+ * interactive prompt when the flag is absent. Exits with a clear error if the
+ * flag is set to an unknown value so non-interactive runs fail fast.
+ */
+export const parseEnvironment = async (): Promise<string> => {
+  if (process.argv.includes('--env')) {
+    const value = getFlagValue('--env')
+    if (!value || !isEnvironmentValue(value)) {
+      console.error(
+        `Error: --env must be one of ${VALID_ENVIRONMENTS.join(', ')}, got '${value ?? ''}'`,
+      )
+      process.exit(1)
+    }
+    return value
+  }
+
+  return select({
+    message: 'Select the environment to use',
+    choices: [
+      { name: 'Prod', value: 'prod' },
+      { name: 'Dev', value: 'dev' },
+      { name: 'Local', value: 'local' },
+    ],
+  })
+}
+
+const VALID_NETWORK_TYPES = ['mainnet', 'testnet'] as const
+type NetworkTypeValue = (typeof VALID_NETWORK_TYPES)[number]
+
+const isNetworkTypeValue = (v: string): v is NetworkTypeValue =>
+  (VALID_NETWORK_TYPES as readonly string[]).includes(v)
+
+/**
+ * Resolve the network type from the `--network` flag, falling back to an
+ * interactive prompt when the flag is absent. Exits with a clear error if the
+ * flag is set to an unknown value so non-interactive runs fail fast.
+ */
+export const parseNetworkType = async (): Promise<'mainnet' | 'testnet'> => {
+  if (process.argv.includes('--network')) {
+    const value = getFlagValue('--network')
+    if (!value || !isNetworkTypeValue(value)) {
+      console.error(
+        `Error: --network must be one of ${VALID_NETWORK_TYPES.join(', ')}, got '${value ?? ''}'`,
+      )
+      process.exit(1)
+    }
+    return value
+  }
+
+  return select({
+    message: 'Select the network type',
+    choices: [
+      { name: 'Mainnet', value: 'mainnet' },
+      { name: 'Testnet', value: 'testnet' },
+    ],
+  })
+}
+
 export const showUserAccount = async (address: string) => {
   console.log(
     `To use your account, you'll need to fund it on the relevant source chain(s). Your account address is ${address}`,
@@ -581,20 +653,7 @@ export const getReplayParams = async () => {
     }
   }
 
-  const isEnvSet = args.includes('--env')
-  let environment: string
-  if (isEnvSet) {
-    environment = args[args.indexOf('--env') + 1]
-  } else {
-    environment = await select({
-      message: 'Select the environment to use',
-      choices: [
-        { name: 'Prod', value: 'prod' },
-        { name: 'Dev', value: 'dev' },
-        { name: 'Local', value: 'local' },
-      ],
-    })
-  }
+  const environment = await parseEnvironment()
 
   const isExecutionModeSet = args.includes('--mode')
   let executionMode: string

--- a/src/get-address.ts
+++ b/src/get-address.ts
@@ -1,28 +1,11 @@
-import { select } from '@inquirer/prompts'
 import { config } from 'dotenv'
-import { parseAccountType } from './cli.js'
+import { parseAccountType, parseEnvironment } from './cli.js'
 import { createRhinestoneAccount } from './main.js'
 
 config()
 
 export const main = async () => {
-  const environmentString = await select({
-    message: 'Select the environments to use',
-    choices: [
-      {
-        name: 'Prod',
-        value: 'prod',
-      },
-      {
-        name: 'Dev',
-        value: 'dev',
-      },
-      {
-        name: 'Local',
-        value: 'local',
-      },
-    ],
-  })
+  const environmentString = await parseEnvironment()
 
   const accountType = parseAccountType()
   const rhinestoneAccount = await createRhinestoneAccount(

--- a/src/get-balance.ts
+++ b/src/get-balance.ts
@@ -1,44 +1,15 @@
-import { select } from '@inquirer/prompts'
 import { config } from 'dotenv'
 import { formatUnits } from 'viem'
-import { parseAccountType } from './cli.js'
+import { parseAccountType, parseEnvironment, parseNetworkType } from './cli.js'
 import { createRhinestoneAccount } from './main.js'
 import { getChainById } from './utils/chains.js'
 
 config()
 
 export const main = async () => {
-  const environmentString = await select({
-    message: 'Select the environments to use',
-    choices: [
-      {
-        name: 'Prod',
-        value: 'prod',
-      },
-      {
-        name: 'Dev',
-        value: 'dev',
-      },
-      {
-        name: 'Local',
-        value: 'local',
-      },
-    ],
-  })
+  const environmentString = await parseEnvironment()
 
-  const networkType = await select({
-    message: 'Select the network type',
-    choices: [
-      {
-        name: 'Mainnet',
-        value: 'mainnet',
-      },
-      {
-        name: 'Testnet',
-        value: 'testnet',
-      },
-    ],
-  })
+  const networkType = await parseNetworkType()
 
   const accountType = parseAccountType()
   const rhinestoneAccount = await createRhinestoneAccount(


### PR DESCRIPTION
## Problem

The `pnpm balance` and `pnpm address` subcommands always dropped into interactive `select` prompts, even when flags like `--env` were passed. This made them unusable in scripts/CI. The `replay` subcommand, by contrast, already parsed `--env`, `--mode`, `--quote`, etc. from `argv` and only prompted when a flag was absent.

The root cause was that `get-address.ts` and `get-balance.ts` hardcoded their own inline `select(...)` prompts instead of reading CLI flags, while `replay` (`getReplayParams`) parsed `process.argv` directly.

## Solution

Extracted the flag-or-prompt pattern that `replay` already used into two shared helpers in `cli.ts`:

- `parseEnvironment()` — reads `--env <prod|dev|local>`, falls back to the interactive prompt when the flag is absent, and exits with a clear error on an unknown value.
- `parseNetworkType()` — reads `--network <mainnet|testnet>` with the same fallback/validation.

Both `address` and `balance` now use these helpers, so they run fully non-interactively when flags are supplied and still prompt otherwise. `getReplayParams` was refactored to reuse `parseEnvironment()` too, so all three subcommands share one code path — this also adds `--env` value validation to `replay`, which previously accepted any string. `--account-type` already worked via the existing `parseAccountType()` and is unchanged.

README updated with the new flags and examples for both commands.

## Behavior

- `pnpm address --env dev` → prints address, no prompt
- `pnpm balance --env dev --network testnet` → prints portfolio, no prompt
- `pnpm address --env staging` → fails fast: `Error: --env must be one of prod, dev, local, got 'staging'`
- `pnpm address` (no flags) → still shows the interactive picker