### PR TITLE
Support app fee quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "ISC",
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
-    "@rhinestone/sdk": "2.0.0-beta.19",
+    "@rhinestone/sdk": "2.0.0-beta.30",
     "abitype": "^1.0.8",
     "dotenv": "^16.5.0",
     "tsx": "^4.19.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.4.1
         version: 7.8.4(@types/node@22.18.1)
       '@rhinestone/sdk':
-        specifier: 2.0.0-beta.19
-        version: 2.0.0-beta.19(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+        specifier: 2.0.0-beta.30
+        version: 2.0.0-beta.30(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
       abitype:
         specifier: ^1.0.8
         version: 1.1.0(typescript@5.9.2)
@@ -401,8 +401,8 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@rhinestone/sdk@2.0.0-beta.19':
-    resolution: {integrity: sha512-wJDpI53mPTvJ6IdQGpR+4g+WBN8OYmDIZ0YE423FJhmwN4VHCxDJsjMWnE/XjxhppjqFxkiaXGAE3QLWa5ElcQ==}
+  '@rhinestone/sdk@2.0.0-beta.30':
+    resolution: {integrity: sha512-LaPqMiXT3JTgNBggNM6SuAOINif6Lu5nFMzuebztI9EMzTtvWbR7P4s7iKyhb+wEbFzt7JAOebtYZRFGgQhdhQ==}
     peerDependencies:
       express: '>=4'
       jose: '>=5.0.0'
@@ -413,8 +413,8 @@ packages:
       jose:
         optional: true
 
-  '@rhinestone/shared-configs@1.5.1':
-    resolution: {integrity: sha512-RtbhW8oQPZeipov1NF3pd4tXvR+C5cac7yhYC0pd2aoE3iBb53U256yvmfyAJ9/s9E0UauT1sNFC/LrLJC+uvA==}
+  '@rhinestone/shared-configs@1.6.7':
+    resolution: {integrity: sha512-QV3ofrvc5kJpysk/g3mTE2WgMutmCdEu4kWNjMMbrDPVWe2QQDEiKpfi34YmFg8UoF6HULbmNUbhn/BniO0Xgw==}
     peerDependencies:
       typescript: ^5
       viem: ^2.40.1
@@ -845,15 +845,15 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@rhinestone/sdk@2.0.0-beta.19(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/sdk@2.0.0-beta.30(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
     dependencies:
-      '@rhinestone/shared-configs': 1.5.1(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+      '@rhinestone/shared-configs': 1.6.7(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
       solady: 0.1.26
       viem: 2.45.0(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
-  '@rhinestone/shared-configs@1.5.1(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/shared-configs@1.6.7(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
     dependencies:
       typescript: 5.9.2
       viem: 2.45.0(typescript@5.9.2)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,17 @@
 import * as fs from 'node:fs'
 import path from 'node:path'
 import { checkbox, confirm, input, select } from '@inquirer/prompts'
-import type { SettlementLayer } from '@rhinestone/sdk'
-import { type Address, type Chain, type Hex, isAddress, parseUnits } from 'viem'
+import type { SettlementLayerFilter } from '@rhinestone/sdk'
+import { type Chain, type Hex, isAddress, parseUnits } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import * as viemChains from 'viem/chains'
 import type { Intent } from './types.js'
 import { getDecimals } from './utils/tokens.js'
+
+type IncludeSettlementLayer = Extract<
+  SettlementLayerFilter,
+  { include: unknown }
+>['include'][number]
 
 // Mirrors the SDK's internal cross-chain layer list, which isn't exported as a
 // runtime value. Keep in sync with @rhinestone/sdk's KNOWN_SETTLEMENT_LAYERS.
@@ -18,9 +23,9 @@ const KNOWN_SETTLEMENT_LAYERS = [
   'NEAR',
   'RHINO',
   'CCTP',
-] as const satisfies readonly SettlementLayer[]
+] as const satisfies readonly IncludeSettlementLayer[]
 
-const isKnownSettlementLayer = (v: unknown): v is SettlementLayer =>
+const isKnownSettlementLayer = (v: unknown): v is IncludeSettlementLayer =>
   typeof v === 'string' &&
   (KNOWN_SETTLEMENT_LAYERS as readonly string[]).includes(v)
 
@@ -364,6 +369,11 @@ export const collectUserInput = async (): Promise<{
       'Fee asset token symbol or address (optional, e.g. USDC, ETH, or 0x...)',
   })
 
+  const appFeeBpsInput = await input({
+    message: 'App fee basis points (optional, e.g. 100 for 1%)',
+  })
+  const appFeeBps = appFeeBpsInput ? Number(appFeeBpsInput) : 0
+
   const recipient = await input({
     message: 'Recipient address for the orchestrator (optional, address)',
   })
@@ -435,12 +445,13 @@ export const collectUserInput = async (): Promise<{
       ...(settlementLayers.length > 0
         ? {
             settlementLayers: {
-              include: settlementLayers as SettlementLayer[],
+              include: settlementLayers as IncludeSettlementLayer[],
             },
           }
         : {}),
       sponsored,
       ...(feeAsset ? { feeAsset } : {}),
+      ...(appFeeBps > 0 ? { appFees: { feeBps: appFeeBps } } : {}),
     },
     saveAsFileName,
     environment,

--- a/src/main.ts
+++ b/src/main.ts
@@ -360,7 +360,10 @@ export const processIntent = async (
       ? ` via ${intent.settlementLayers.include.join()}`
       : ` excluding ${intent.settlementLayers.exclude.join()}`
     : ''
-  const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${settlementLayersLabel}${intent.sponsored ? ' sponsored' : ''} to ${recipientLabel}`
+  const appFeeLabel = intent.appFees
+    ? ` +${intent.appFees.feeBps}bps appFee`
+    : ''
+  const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${settlementLayersLabel}${intent.sponsored ? ' sponsored' : ''}${appFeeLabel} to ${recipientLabel}`
 
   console.log(`${ts()} Bundle ${bundleLabel}: Starting transaction process`)
 
@@ -392,6 +395,7 @@ export const processIntent = async (
       : {}),
     ...(intent.recipient ? { recipient: intent.recipient as Address } : {}),
     ...(intent.feeAsset ? { feeAsset: intent.feeAsset } : {}),
+    ...(intent.appFees ? { appFees: intent.appFees } : {}),
     ...(resolvedAuxiliaryFunds
       ? { auxiliaryFunds: resolvedAuxiliaryFunds }
       : {}),
@@ -426,6 +430,12 @@ export const processIntent = async (
       console.log(
         `${ts()} Bundle ${bundleLabel}: [verbose] ${marker} [${i}] ${quote.settlementLayer} (intentId=${quote.intentId}, fillTime=${quote.estimatedFillTime.seconds}s, fees=$${quote.cost.fees.total.usd})`,
       )
+      console.log(
+        `${ts()} Bundle ${bundleLabel}: [verbose] app fee: $${quote.cost.fees.breakdown.app?.usd ?? 0}`,
+      )
+      if (quote.appFee?.length) {
+        console.dir({ appFee: quote.appFee }, { depth: null })
+      }
       const {
         signData: _signData,
         tokenRequirements: _tokenRequirements,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { SettlementLayerFilter } from '@rhinestone/sdk'
+import type { AppFeeRate, SettlementLayerFilter } from '@rhinestone/sdk'
 import type { Address } from 'abitype'
 
 export type Token = {
@@ -35,6 +35,7 @@ export type Intent = {
   sponsored: boolean
   destinationOps?: boolean
   feeAsset?: string
+  appFees?: AppFeeRate
   auxiliaryFunds?: Record<string, Record<string, string>>
 }
 


### PR DESCRIPTION
Adds app-fee support to the bundle generator so it can request app-fee-inclusive routes and inspect the quoted impact, now that the orchestrator and SDK expose app fees.

Bumps `@rhinestone/sdk` to the published `2.0.0-beta.30` (which carries the app-fee quote surface) and removes the temporary local SDK tarball override used during development.

Changes:
- New `appFees` field on the intent type and an interactive CLI prompt for app-fee basis points.
- Threads `appFees` into the prepared transaction.
- Verbose output now prints the app-fee USD and the concrete `quote.appFee` legs.
- Adapts the CLI's settlement-layer typing to the SDK's `SettlementLayerFilter` shape required by beta.30.

Validated against the local stack: a smart-account ACROSS route with `appFees.feeBps: 100` returns `cost.fees.breakdown.app.usd` > 0 and a concrete `appFee[]` leg; the EOA path (app fees unsupported by design) returns app USD 0 and `appFee: []`.