### PR TITLE
fix: enrich receipts via local fork RPC

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import {
   getChain,
   getChainById,
   getEvmChain,
+  getLocalForkRpcUrl,
   isNonEvmChain,
 } from './utils/chains.js'
 import { getEnvironment } from './utils/environments.js'
@@ -521,11 +522,20 @@ export const processIntent = async (
       // Non-EVM chains have no viem RPC — skip receipt enrichment there.
       // Bundle status tracking for non-EVM dests is tracked separately (RHI-3797).
       if (!isSimulate && op.hash && !isNonEvmChain(op.chainId)) {
+        // Against the local stack, on-chain reads must hit the anvil fork RPC,
+        // not viem's default public mainnet RPC — otherwise a tx that only
+        // exists on the fork is "not found". Use waitForTransactionReceipt so
+        // receipt enrichment doesn't race the block (the intent already reached
+        // a terminal state via waitForExecution above).
+        const forkRpcUrl =
+          environmentString === 'local'
+            ? getLocalForkRpcUrl(op.chainId)
+            : undefined
         const publicClient = createPublicClient({
           chain: getChainById(op.chainId),
-          transport: http(),
+          transport: forkRpcUrl ? http(forkRpcUrl) : http(),
         })
-        const txReceipt = await publicClient.getTransactionReceipt({
+        const txReceipt = await publicClient.waitForTransactionReceipt({
           hash: op.hash as Hex,
         })
         op.gasUsed = txReceipt.gasUsed

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -65,3 +65,21 @@ export const getChainById = (chainId: number): Chain => {
   }
   return chain as Chain
 }
+
+// Local anvil fork RPC endpoints, keyed by chainId. Ports follow the e2e stack
+// convention (chains exposed on 30001-30008). Used so on-chain reads (e.g.
+// receipt enrichment) hit the local fork instead of viem's default public
+// mainnet RPC — otherwise a tx that only exists on the fork is "not found".
+const LOCAL_FORK_RPC_BY_CHAIN_ID: Record<number, string> = {
+  1: 'http://localhost:30001', // mainnet
+  42161: 'http://localhost:30002', // arbitrum
+  8453: 'http://localhost:30003', // base
+  137: 'http://localhost:30004', // polygon
+  146: 'http://localhost:30005', // sonic
+  10: 'http://localhost:30006', // optimism
+  100: 'http://localhost:30007', // gnosis
+  9745: 'http://localhost:30008', // plasma
+}
+
+export const getLocalForkRpcUrl = (chainId: number): string | undefined =>
+  LOCAL_FORK_RPC_BY_CHAIN_ID[chainId]


### PR DESCRIPTION
## Problem

Running `replay ... --mode execute` against the local stack (`--env local`) failed at the end with `TransactionReceiptNotFoundError`, even though the intent had fully settled (claim + fill completed on the anvil forks). The error surfaced as `Submission/Execution failed`, masking otherwise-successful runs and making local e2e execution appear broken.

Root cause: after `waitForExecution` succeeds, the CLI does a "receipt enrichment" pass (gas used, block timestamp) by constructing a `publicClient` with a bare `http()` transport — which resolves to viem's **default public mainnet RPC** for the chain, not the local anvil fork. A tx that only exists on the fork is therefore "not found". A secondary issue: it used `getTransactionReceipt` (single-shot), which can race the block.

## Fix

- Add a chainId → local fork RPC map (`getLocalForkRpcUrl`) following the e2e stack port convention (chains exposed on `30001`–`30008`).
- In the receipt-enrichment path, when running `--env local`, point the `publicClient` at the fork RPC; otherwise keep the default transport unchanged for dev/prod.
- Use `waitForTransactionReceipt` instead of `getTransactionReceipt` so enrichment doesn't race the block (the intent has already reached a terminal state via `waitForExecution`).

Receipt enrichment is purely informational (it populates `gasUsed`/fill timestamp for the timing summary); this change does not affect signing, submission, or settlement. Dev/prod behavior is unchanged.

## Validation

`replay local-smart-arb-base-usdc-across-appfee --env local --mode execute` now completes cleanly ("Execution completed", full timing summary) with no receipt error, against the local fork stack.