### PR TITLE
feat: add app-fee-balance command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "replay": "tsx src/existing-intent.ts",
     "address": "tsx src/get-address.ts",
     "balance": "tsx src/get-balance.ts",
+    "app-fee-balance": "tsx src/get-app-fee-balance.ts",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "format": "biome format .",
@@ -20,7 +21,7 @@
   "license": "ISC",
   "dependencies": {
     "@inquirer/prompts": "^7.4.1",
-    "@rhinestone/sdk": "2.0.0-beta.30",
+    "@rhinestone/sdk": "2.0.0-beta.38",
     "abitype": "^1.0.8",
     "dotenv": "^16.5.0",
     "tsx": "^4.19.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^7.4.1
         version: 7.8.4(@types/node@22.18.1)
       '@rhinestone/sdk':
-        specifier: 2.0.0-beta.30
-        version: 2.0.0-beta.30(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+        specifier: 2.0.0-beta.38
+        version: 2.0.0-beta.38(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
       abitype:
         specifier: ^1.0.8
         version: 1.1.0(typescript@5.9.2)
@@ -401,8 +401,8 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@rhinestone/sdk@2.0.0-beta.30':
-    resolution: {integrity: sha512-LaPqMiXT3JTgNBggNM6SuAOINif6Lu5nFMzuebztI9EMzTtvWbR7P4s7iKyhb+wEbFzt7JAOebtYZRFGgQhdhQ==}
+  '@rhinestone/sdk@2.0.0-beta.38':
+    resolution: {integrity: sha512-MYniDkRMkKgPyDq4ScuRx2JHBf1rveu8tPzebl8RmkaJ+XWaphIJZyNYYJOXRGY/5bPWA4uL7XSbc/k9io1v7w==}
     peerDependencies:
       express: '>=4'
       jose: '>=5.0.0'
@@ -413,8 +413,8 @@ packages:
       jose:
         optional: true
 
-  '@rhinestone/shared-configs@1.6.7':
-    resolution: {integrity: sha512-QV3ofrvc5kJpysk/g3mTE2WgMutmCdEu4kWNjMMbrDPVWe2QQDEiKpfi34YmFg8UoF6HULbmNUbhn/BniO0Xgw==}
+  '@rhinestone/shared-configs@1.7.0':
+    resolution: {integrity: sha512-Jm3lIQyRs7lvIwuRadwwvAEY2rleJLadpm6amLPvRVzPkOY33+zqBG3Q+A0HroyN3Wt2SIAq8QLyGRs5pKSA8Q==}
     peerDependencies:
       typescript: ^5
       viem: ^2.40.1
@@ -845,15 +845,15 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@rhinestone/sdk@2.0.0-beta.30(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/sdk@2.0.0-beta.38(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
     dependencies:
-      '@rhinestone/shared-configs': 1.6.7(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+      '@rhinestone/shared-configs': 1.7.0(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
       solady: 0.1.26
       viem: 2.45.0(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
-  '@rhinestone/shared-configs@1.6.7(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/shared-configs@1.7.0(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
     dependencies:
       typescript: 5.9.2
       viem: 2.45.0(typescript@5.9.2)

--- a/src/get-app-fee-balance.ts
+++ b/src/get-app-fee-balance.ts
@@ -1,0 +1,40 @@
+import { select } from '@inquirer/prompts'
+import { RhinestoneSDK } from '@rhinestone/sdk'
+import { config } from 'dotenv'
+import { getEnvironment } from './utils/environments.js'
+
+config()
+
+// Prints the integrator's accrued app-fee balance (USD totals) from
+// GET /app-fees/balances via the SDK's RhinestoneSDK.getAppFeeBalances().
+// The balance is project-scoped (keyed to the env's *_API_KEY), not tied to any
+// account, so this talks to the SDK instance directly. Supports
+// `--env <local|dev|prod>` non-interactively, else prompts.
+export const main = async () => {
+  const args = process.argv
+  const environmentString = args.includes('--env')
+    ? args[args.indexOf('--env') + 1]
+    : await select({
+        message: 'Select the environment to use',
+        choices: [
+          { name: 'Prod', value: 'prod' },
+          { name: 'Dev', value: 'dev' },
+          { name: 'Local', value: 'local' },
+        ],
+      })
+
+  const environment = getEnvironment(environmentString)
+  const sdk = new RhinestoneSDK({
+    apiKey: environment.apiKey,
+    endpointUrl: environment.url,
+    useDevContracts: environment.useDevContracts,
+  })
+
+  const balances = await sdk.getAppFeeBalances()
+
+  console.log(`App-fee balance (env: ${environmentString}):`)
+  console.log(`   withdrawableUsd: $${balances.withdrawableUsd}`)
+  console.log(`   pendingUsd:      $${balances.pendingUsd}`)
+}
+
+main().catch(console.error)

--- a/src/main.ts
+++ b/src/main.ts
@@ -434,9 +434,6 @@ export const processIntent = async (
       console.log(
         `${ts()} Bundle ${bundleLabel}: [verbose] app fee: $${quote.cost.fees.breakdown.app?.usd ?? 0}`,
       )
-      if (quote.appFee?.length) {
-        console.dir({ appFee: quote.appFee }, { depth: null })
-      }
       const {
         signData: _signData,
         tokenRequirements: _tokenRequirements,


### PR DESCRIPTION
## What

Adds an `app-fee-balance` command to read an integrator's accrued app-fee balance (USD totals) from the orchestrator's `GET /app-fees/balances`, via the SDK's new `RhinestoneSDK.getAppFeeBalances()`.

```bash
pnpm app-fee-balance --env dev      # or local / prod; prompts if --env omitted
```

Output:

```
App-fee balance (env: dev):
   withdrawableUsd: $0
   pendingUsd:      $0
```

## Changes

- `src/get-app-fee-balance.ts`: new command. Builds a `RhinestoneSDK` from the selected env (`getEnvironment`) and calls `getAppFeeBalances()`. The balance is **project-scoped** (keyed to the env's `*_API_KEY`), not tied to any account, so it talks to the SDK instance directly rather than constructing an account. Supports `--env <local|dev|prod>` non-interactively, else prompts.
- `package.json`: `app-fee-balance` script; bump `@rhinestone/sdk` to `2.0.0-beta.38` (first published beta with `getAppFeeBalances`).

## Verification

- Runs end-to-end against the deployed **dev** orchestrator using the published SDK beta.38: returns `{ withdrawableUsd: 0, pendingUsd: 0 }`, matching the raw endpoint.
- New command file is biome-clean.
