### PR TITLE
feat: Rhinestone protocol fee support (RHI-4904)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -374,6 +374,21 @@ export const collectUserInput = async (): Promise<{
   })
   const appFeeBps = appFeeBpsInput ? Number(appFeeBpsInput) : 0
 
+  const protocolFeeBpsInput = await input({
+    message: 'Rhinestone protocol fee basis points (optional, e.g. 35)',
+  })
+  const protocolFeeBps = protocolFeeBpsInput ? Number(protocolFeeBpsInput) : 0
+  const sponsorProtocolFee =
+    protocolFeeBps > 0 && sponsored
+      ? await select({
+          message: 'Sponsor the protocol fee (charge it to the sponsor)?',
+          choices: [
+            { name: 'Yes', value: true },
+            { name: 'No', value: false },
+          ],
+        })
+      : false
+
   const recipient = await input({
     message: 'Recipient address for the orchestrator (optional, address)',
   })
@@ -449,9 +464,14 @@ export const collectUserInput = async (): Promise<{
             },
           }
         : {}),
-      sponsored,
+      sponsored: sponsorProtocolFee
+        ? { gas: true, bridging: true, swaps: true, protocolFees: true }
+        : sponsored,
       ...(feeAsset ? { feeAsset } : {}),
       ...(appFeeBps > 0 ? { appFees: { feeBps: appFeeBps } } : {}),
+      ...(protocolFeeBps > 0
+        ? { protocolFees: { feeBps: protocolFeeBps } }
+        : {}),
     },
     saveAsFileName,
     environment,

--- a/src/main.ts
+++ b/src/main.ts
@@ -364,7 +364,19 @@ export const processIntent = async (
   const appFeeLabel = intent.appFees
     ? ` +${intent.appFees.feeBps}bps appFee`
     : ''
-  const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${settlementLayersLabel}${intent.sponsored ? ' sponsored' : ''}${appFeeLabel} to ${recipientLabel}`
+  const protocolFeeLabel = intent.protocolFees
+    ? ` +${intent.protocolFees.feeBps}bps protocolFee`
+    : ''
+  const sponsoredLabel =
+    typeof intent.sponsored === 'object'
+      ? ` sponsored(${Object.entries(intent.sponsored)
+          .filter(([, v]) => v)
+          .map(([k]) => k)
+          .join(',')})`
+      : intent.sponsored
+        ? ' sponsored'
+        : ''
+  const bundleLabel = `${sourceAssetsLabel} > ${targetAssetsLabel}${settlementLayersLabel}${sponsoredLabel}${appFeeLabel}${protocolFeeLabel} to ${recipientLabel}`
 
   console.log(`${ts()} Bundle ${bundleLabel}: Starting transaction process`)
 
@@ -397,6 +409,7 @@ export const processIntent = async (
     ...(intent.recipient ? { recipient: intent.recipient as Address } : {}),
     ...(intent.feeAsset ? { feeAsset: intent.feeAsset } : {}),
     ...(intent.appFees ? { appFees: intent.appFees } : {}),
+    ...(intent.protocolFees ? { protocolFees: intent.protocolFees } : {}),
     ...(resolvedAuxiliaryFunds
       ? { auxiliaryFunds: resolvedAuxiliaryFunds }
       : {}),
@@ -433,6 +446,17 @@ export const processIntent = async (
       )
       console.log(
         `${ts()} Bundle ${bundleLabel}: [verbose] app fee: $${quote.cost.fees.breakdown.app?.usd ?? 0}`,
+      )
+      // `protocol` / `sponsorSurcharge` land in the generated wire types when
+      // the SDK regenerates against the orchestrator's RHI-4904 OpenAPI;
+      // widen locally until the dep bump.
+      const breakdown = quote.cost.fees
+        .breakdown as typeof quote.cost.fees.breakdown & {
+        protocol?: { usd: number; sponsored: boolean }
+        sponsorSurcharge?: { usd: number; sponsored: boolean }
+      }
+      console.log(
+        `${ts()} Bundle ${bundleLabel}: [verbose] protocol fee: $${breakdown.protocol?.usd ?? 0} (sponsored: ${breakdown.protocol?.sponsored ?? false}) | sponsor surcharge: $${breakdown.sponsorSurcharge?.usd ?? 0}`,
       )
       const {
         signData: _signData,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,18 @@
 import type { AppFeeRate, SettlementLayerFilter } from '@rhinestone/sdk'
+
+/** Rate for the Rhinestone protocol fee (RHI-4904). Defined locally until the
+ * dep bumps to an SDK release exporting `ProtocolFeeRate`. */
+export type ProtocolFeeRate = { feeBps: number }
+
+/** Object form of the SDK's `Sponsorship`: per-category sponsorship flags,
+ * including the sponsorable Rhinestone protocol fee (RHI-4904). */
+export type SponsorshipSettings = {
+  gas: boolean
+  bridging: boolean
+  swaps: boolean
+  protocolFees?: boolean
+}
+
 import type { Address } from 'abitype'
 
 export type Token = {
@@ -32,10 +46,11 @@ export type Intent = {
   tokenRecipient: string
   recipient?: string
   settlementLayers?: SettlementLayerFilter
-  sponsored: boolean
+  sponsored: boolean | SponsorshipSettings
   destinationOps?: boolean
   feeAsset?: string
   appFees?: AppFeeRate
+  protocolFees?: ProtocolFeeRate
   auxiliaryFunds?: Record<string, Record<string, string>>
 }
 


### PR DESCRIPTION
## Summary

Drive the orchestrator's new **Rhinestone protocol fee** ([orchestrator#1756](https://github.com/rhinestonewtf/orchestrator/pull/1756), [sdk#671](https://github.com/rhinestonewtf/sdk/pull/671)) from intent definitions:

- `protocolFees: { feeBps }` on intent JSON + an interactive CLI prompt, passed through to the SDK exactly like `appFees`.
- `sponsored` now also accepts the SDK's object form (`{ gas, bridging, swaps, protocolFees }`) so a sponsored protocol fee is expressible; the CLI offers it when both a protocol fee and sponsorship are selected.
- Bundle labels render both fee rates and the per-category sponsorship; verbose mode prints each route's `protocol` fee line (`usd` + `sponsored`) and the pure `sponsorSurcharge` — the vetting output for local-stack runs.

The new wire-breakdown fields are widened locally with a documented cast until the SDK dep bumps to a release regenerated against the RHI-4904 OpenAPI; against older orchestrators the option is ignored and the verbose line prints zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Merge ordering (blocked)

**Depends on [rhinestonewtf/sdk#671](https://github.com/rhinestonewtf/sdk/pull/671) shipping in an SDK release.** The pinned `@rhinestone/sdk@2.0.0-beta.38` drops `protocolFees` inside `prepareTransaction` (rhinestone-kevin's blocker below is correct), so merging now would label a fee the intent doesn't carry. Once the SDK cuts a release containing #671, this PR bumps the pin and the passthrough becomes real — that bump will land here before this leaves draft.

Local-stack validation note: the four RHI-4904 scenarios (carve / stacked / sponsored-protocol / sponsored-all) were run end-to-end through this branch with the sdk#671 changes applied to the local install, against orchestrator [#1756](https://github.com/rhinestonewtf/orchestrator/pull/1756) — labels, verbose fee lines, and wire breakdowns all reconciled exactly (evidence on the orchestrator PR).
