### PR TITLE
chore: upgrade to @rhinestone/sdk v2 stable, and bump every dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ pnpm new                  # interactive: build, save and run a new intent
 pnpm replay               # replay saved intents from intents/
 pnpm app-fee-balance
 
-pnpm check                # biome lint + format — the only quality gate
+pnpm typecheck            # tsc --noEmit
+pnpm check                # biome lint + format
 pnpm check:fix
 ```
 
@@ -96,9 +97,25 @@ Every command takes `--env <prod|dev|local>` and prompts if omitted.
   SDK's list, which isn't exported as a runtime value. A layer added to
   `@rhinestone/sdk` is rejected here until this array is updated.
 - **There is no CI.** The repo has no `.github/` directory at all — no build, no
-  typecheck, no test on a pull request. `pnpm check` locally is the entire
-  quality gate, and `tsc` is never run in isolation (`tsx` transpiles without
-  type-checking), so a type error can be merged and only surfaces at runtime.
+  typecheck, no test on a pull request. `pnpm check` + `pnpm typecheck` locally
+  are the entire quality gate, and `tsx` transpiles without type-checking, so a
+  type error can be merged and only surfaces at runtime.
+- **The account address derives from the account descriptor, so the SDK's
+  default account version is load-bearing.** `createRhinestoneAccount` pins
+  `nexus 1.2.1`; SDK v2 moved that default up from 1.2.0 and silently re-derived
+  every account to a new address, which surfaces as `No balances available` on
+  an account that is provably funded on-chain. Changing it means migrating the
+  float first — and the *old* account has to sign that, so the pin moves last.
+- **SDK v2 rejects token symbols** (`normalizeTokenAddress` wants a hex address
+  on every EVM chain) and `GET /chains` can't fill the gap — it reports
+  `supportedTokens: 'all'` for most chains. Intent files stay symbol-based;
+  `src/utils/registry.ts` resolves them from the chain-facts artifact at
+  runtime, deliberately unpinned so a new chain needs no dependency bump.
+- **Neither "it errored" nor "it submitted" tells you whether an intent
+  settled.** Receipt enrichment runs after `waitForExecution` on viem's default
+  public RPC, so a lagging RPC throws `BlockNotFoundError` on a completed
+  intent; conversely a submitted intent can still end `FAILED`/`EXPIRED`. Read
+  `sdk.getIntentStatus(intentId)`, or the chain.
 - **`intents/` is gitignored.** Saved intents never leave your machine, so
   "replay the intent from that bug" means someone has to paste the JSON. Keep
   reproductions in the ticket, not just on disk.

--- a/biome.json
+++ b/biome.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.7/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "formatter": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "address": "tsx src/get-address.ts",
     "balance": "tsx src/get-balance.ts",
     "app-fee-balance": "tsx src/get-app-fee-balance.ts",
+    "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "format": "biome format .",
@@ -20,16 +21,16 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@inquirer/prompts": "^7.4.1",
-    "@rhinestone/sdk": "2.0.0-beta.38",
-    "abitype": "^1.0.8",
-    "dotenv": "^16.5.0",
-    "tsx": "^4.19.4",
-    "typescript": "^5.8.3",
-    "viem": "^2.45.0"
+    "@inquirer/prompts": "^8.5.2",
+    "@rhinestone/sdk": "2.2.1",
+    "abitype": "^1.3.0",
+    "dotenv": "^17.4.2",
+    "tsx": "^4.23.9",
+    "typescript": "^7.0.2",
+    "viem": "^2.55.11"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.3.12",
-    "@types/node": "^22.15.16"
+    "@biomejs/biome": "^2.5.7",
+    "@types/node": "^26.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,376 +9,380 @@ importers:
   .:
     dependencies:
       '@inquirer/prompts':
-        specifier: ^7.4.1
-        version: 7.8.4(@types/node@22.18.1)
+        specifier: ^8.5.2
+        version: 8.5.2(@types/node@26.1.2)
       '@rhinestone/sdk':
-        specifier: 2.0.0-beta.38
-        version: 2.0.0-beta.38(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
+        specifier: 2.2.1
+        version: 2.2.1(viem@2.55.11(typescript@7.0.2))
       abitype:
-        specifier: ^1.0.8
-        version: 1.1.0(typescript@5.9.2)
+        specifier: ^1.3.0
+        version: 1.3.0(typescript@7.0.2)
       dotenv:
-        specifier: ^16.5.0
-        version: 16.6.1
+        specifier: ^17.4.2
+        version: 17.4.2
       tsx:
-        specifier: ^4.19.4
-        version: 4.20.5
+        specifier: ^4.23.9
+        version: 4.23.9
       typescript:
-        specifier: ^5.8.3
-        version: 5.9.2
+        specifier: ^7.0.2
+        version: 7.0.2
       viem:
-        specifier: ^2.45.0
-        version: 2.45.0(typescript@5.9.2)
+        specifier: ^2.55.11
+        version: 2.55.11(typescript@7.0.2)
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.3.12
-        version: 2.3.13
+        specifier: ^2.5.7
+        version: 2.5.7
       '@types/node':
-        specifier: ^22.15.16
-        version: 22.18.1
+        specifier: ^26.1.2
+        version: 26.1.2
 
 packages:
 
   '@adraffy/ens-normalize@1.11.0':
     resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
-  '@biomejs/biome@2.3.13':
-    resolution: {integrity: sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==}
+  '@biomejs/biome@2.5.7':
+    resolution: {integrity: sha512-zr8K/DcY5tYsQOQwqMJ0AWElo6QgmgNI7idXgXLhevVszlt8RGVpesEJPqx3ThazLaOwjJ5Y8fz3BtH5fGZNsw==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.13':
-    resolution: {integrity: sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==}
+  '@biomejs/cli-darwin-arm64@2.5.7':
+    resolution: {integrity: sha512-vxo/Ls3/PYdQWyLhYYcgMOCzQypAjcY+iihS8M0wW03l16TCLW4zqZzGo75gm1VdCMj38hTVZ31KBWrZ4G9dJw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.13':
-    resolution: {integrity: sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==}
+  '@biomejs/cli-darwin-x64@2.5.7':
+    resolution: {integrity: sha512-Cd3Ga61amT/Yl/0x8elP5hhGYaFy4bw6WuysTgf7oo8TA5tJ5A1k+DkVoJ2BHbTVil51gTX9VPzArnrlLJ3Kyg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.13':
-    resolution: {integrity: sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==}
+  '@biomejs/cli-linux-arm64-musl@2.5.7':
+    resolution: {integrity: sha512-xPI5yB6XlpDbNkS+bm1t42olw5c4l3UrlOmLg7KtLJvjvkNF/1V4tnUgfkylGIeb3u/T+BzMGYqgQhzjAoJzuQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.13':
-    resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
+  '@biomejs/cli-linux-arm64@2.5.7':
+    resolution: {integrity: sha512-rR2QE0yF2GYSuYuKIa7pKvODGJqnOH+2eDREAM8wV+mWKSkMQKdAp4zXEZfTaxY8PMoNONnpgSWcBCyLDPDOKg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.13':
-    resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
+  '@biomejs/cli-linux-x64-musl@2.5.7':
+    resolution: {integrity: sha512-rE5VZi+qtmPgQH+l7jVxYoZ18b/TiHEhulhMpjmCZH1PltSbjRcxNWywC3HZ9tYottG7ORkeTtoscBilKSBm0g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.13':
-    resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
+  '@biomejs/cli-linux-x64@2.5.7':
+    resolution: {integrity: sha512-FQgqJhscrqJUFptGaRSUJWlXAExwWcDwLuK49dvKfkQ1bB5SEEyFssnsxQY83Xm6jR0EbbX3+8+D5bfvYqUG2Q==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.13':
-    resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
+  '@biomejs/cli-win32-arm64@2.5.7':
+    resolution: {integrity: sha512-Oq4x0CCwP4jirrcTywXs5kOGZ4v5vuEP+gWrbtjApOA2CL9F3F9GlIdQIci8AKSCa/zURanMRpX/4wQ7Am6hHg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.13':
-    resolution: {integrity: sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==}
+  '@biomejs/cli-win32-x64@2.5.7':
+    resolution: {integrity: sha512-V+0wu/nrj2S+MhP4EQ0uHNolP0IALEsz45pg0WoKkHfDeh0+ItHwP/p7bX5RPoMOl9NkpHYWdYPhIcy2mACHvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/aix-ppc64@0.25.9':
-    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.9':
-    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.9':
-    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.9':
-    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.9':
-    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.9':
-    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.9':
-    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.9':
-    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.9':
-    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.9':
-    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.9':
-    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.9':
-    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.9':
-    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.9':
-    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.9':
-    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.9':
-    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.9':
-    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.9':
-    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.9':
-    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.9':
-    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.9':
-    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.9':
-    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.9':
-    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.9':
-    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.9':
-    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@inquirer/checkbox@4.2.2':
-    resolution: {integrity: sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==}
-    engines: {node: '>=18'}
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@5.1.16':
-    resolution: {integrity: sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==}
-    engines: {node: '>=18'}
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/core@10.2.0':
-    resolution: {integrity: sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==}
-    engines: {node: '>=18'}
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@4.2.18':
-    resolution: {integrity: sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w==}
-    engines: {node: '>=18'}
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@4.0.18':
-    resolution: {integrity: sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag==}
-    engines: {node: '>=18'}
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@1.0.1':
-    resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
-    engines: {node: '>=18'}
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.13':
-    resolution: {integrity: sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==}
-    engines: {node: '>=18'}
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/input@4.2.2':
-    resolution: {integrity: sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw==}
-    engines: {node: '>=18'}
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/number@3.0.18':
-    resolution: {integrity: sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A==}
-    engines: {node: '>=18'}
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/password@4.0.18':
-    resolution: {integrity: sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA==}
-    engines: {node: '>=18'}
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/prompts@7.8.4':
-    resolution: {integrity: sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg==}
-    engines: {node: '>=18'}
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@4.1.6':
-    resolution: {integrity: sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA==}
-    engines: {node: '>=18'}
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/search@3.1.1':
-    resolution: {integrity: sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA==}
-    engines: {node: '>=18'}
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/select@4.3.2':
-    resolution: {integrity: sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w==}
-    engines: {node: '>=18'}
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@inquirer/type@3.0.8':
-    resolution: {integrity: sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==}
-    engines: {node: '>=18'}
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -401,23 +405,17 @@ packages:
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
-  '@rhinestone/sdk@2.0.0-beta.38':
-    resolution: {integrity: sha512-MYniDkRMkKgPyDq4ScuRx2JHBf1rveu8tPzebl8RmkaJ+XWaphIJZyNYYJOXRGY/5bPWA4uL7XSbc/k9io1v7w==}
+  '@rhinestone/sdk@2.2.1':
+    resolution: {integrity: sha512-pWSmq8KZqxqZVPYe3ydw+I48SD2UdIFyIN8CZGPORrGrBYAt9WBBYPR3PkyKuKTNdkcSUaFOvJntVCC15J8vew==}
     peerDependencies:
       express: '>=4'
       jose: '>=5.0.0'
-      viem: ^2.38.0
+      viem: ^2.55.0
     peerDependenciesMeta:
       express:
         optional: true
       jose:
         optional: true
-
-  '@rhinestone/shared-configs@1.7.0':
-    resolution: {integrity: sha512-Jm3lIQyRs7lvIwuRadwwvAEY2rleJLadpm6amLPvRVzPkOY33+zqBG3Q+A0HroyN3Wt2SIAq8QLyGRs5pKSA8Q==}
-    peerDependencies:
-      typescript: ^5
-      viem: ^2.40.1
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -428,19 +426,128 @@ packages:
   '@scure/bip39@1.6.0':
     resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
-  '@types/node@22.18.1':
-    resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
-  abitype@1.1.0:
-    resolution: {integrity: sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A==}
-    peerDependencies:
-      typescript: '>=5.0.4'
-      zod: ^3.22.0 || ^4.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-      zod:
-        optional: true
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
 
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
@@ -453,82 +560,70 @@ packages:
       zod:
         optional: true
 
-  ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
+  abitype@1.3.0:
+    resolution: {integrity: sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3.22.0 || ^4.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
-
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
-  chardet@2.1.0:
-    resolution: {integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==}
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  dotenv@16.6.1:
-    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  esbuild@0.25.9:
-    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  get-tsconfig@4.10.1:
-    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
-
-  iconv-lite@0.6.3:
-    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
-    engines: {node: '>=8'}
 
   isows@1.0.7:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
 
-  mute-stream@2.0.0:
-    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
-  ox@0.11.3:
-    resolution: {integrity: sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==}
+  ox@0.14.33:
+    resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  resolve-pkg-maps@1.0.0:
-    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -537,48 +632,29 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  solady@0.1.26:
-    resolution: {integrity: sha512-dhGr/ptJFdea/1KE6xgqgwEdbMhUiSfRc6A+jLeltPe16zyt9qtED3PElIBVRnzEmUO5aZTjKVAr6SlqXBBcIw==}
-
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
-
-  tsx@4.20.5:
-    resolution: {integrity: sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==}
+  tsx@4.23.9:
+    resolution: {integrity: sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
-
-  typescript@5.9.2:
-    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  viem@2.45.0:
-    resolution: {integrity: sha512-iVA9qrAgRdtpWa80lCZ6Jri6XzmLOwwA1wagX2HnKejKeliFLpON0KOdyfqvcy+gUpBVP59LBxP2aKiL3aj8fg==}
+  viem@2.55.11:
+    resolution: {integrity: sha512-RR5MwtdUnFfqw6ZGoFptizywyLOkLuhTL7UafoP3Irf2upXpANakQkLgGqY4H7A7+8JBxjUs6lElGF5zuGjMEw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
       typescript:
         optional: true
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
-
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -589,249 +665,241 @@ packages:
       utf-8-validate:
         optional: true
 
-  yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
-
 snapshots:
 
   '@adraffy/ens-normalize@1.11.0': {}
 
-  '@biomejs/biome@2.3.13':
+  '@biomejs/biome@2.5.7':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.13
-      '@biomejs/cli-darwin-x64': 2.3.13
-      '@biomejs/cli-linux-arm64': 2.3.13
-      '@biomejs/cli-linux-arm64-musl': 2.3.13
-      '@biomejs/cli-linux-x64': 2.3.13
-      '@biomejs/cli-linux-x64-musl': 2.3.13
-      '@biomejs/cli-win32-arm64': 2.3.13
-      '@biomejs/cli-win32-x64': 2.3.13
+      '@biomejs/cli-darwin-arm64': 2.5.7
+      '@biomejs/cli-darwin-x64': 2.5.7
+      '@biomejs/cli-linux-arm64': 2.5.7
+      '@biomejs/cli-linux-arm64-musl': 2.5.7
+      '@biomejs/cli-linux-x64': 2.5.7
+      '@biomejs/cli-linux-x64-musl': 2.5.7
+      '@biomejs/cli-win32-arm64': 2.5.7
+      '@biomejs/cli-win32-x64': 2.5.7
 
-  '@biomejs/cli-darwin-arm64@2.3.13':
+  '@biomejs/cli-darwin-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.13':
+  '@biomejs/cli-darwin-x64@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.13':
+  '@biomejs/cli-linux-arm64-musl@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.13':
+  '@biomejs/cli-linux-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.13':
+  '@biomejs/cli-linux-x64-musl@2.5.7':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.13':
+  '@biomejs/cli-linux-x64@2.5.7':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.13':
+  '@biomejs/cli-win32-arm64@2.5.7':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.13':
+  '@biomejs/cli-win32-x64@2.5.7':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.9':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.25.9':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.25.9':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.25.9':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.9':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.9':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.9':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.9':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.9':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.25.9':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.9':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.9':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.9':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.9':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.9':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.9':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.25.9':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.9':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.9':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.9':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.9':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.9':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.9':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.9':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.9':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.25.9':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@inquirer/checkbox@4.2.2(@types/node@22.18.1)':
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/checkbox@5.2.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      ansi-escapes: 4.3.2
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/confirm@5.1.16(@types/node@22.18.1)':
+  '@inquirer/confirm@6.1.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/core@10.2.0(@types/node@22.18.1)':
+  '@inquirer/core@11.2.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      ansi-escapes: 4.3.2
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
       cli-width: 4.1.0
-      mute-stream: 2.0.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
       signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/editor@4.2.18(@types/node@22.18.1)':
+  '@inquirer/editor@5.2.2(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/external-editor': 1.0.1(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/external-editor': 3.0.3(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/expand@4.0.18(@types/node@22.18.1)':
+  '@inquirer/expand@5.1.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/external-editor@1.0.1(@types/node@22.18.1)':
+  '@inquirer/external-editor@3.0.3(@types/node@26.1.2)':
     dependencies:
-      chardet: 2.1.0
-      iconv-lite: 0.6.3
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/figures@1.0.13': {}
+  '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@4.2.2(@types/node@22.18.1)':
+  '@inquirer/input@5.1.2(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/number@3.0.18(@types/node@22.18.1)':
+  '@inquirer/number@4.1.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/password@4.0.18(@types/node@22.18.1)':
+  '@inquirer/password@5.1.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      ansi-escapes: 4.3.2
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/prompts@7.8.4(@types/node@22.18.1)':
+  '@inquirer/prompts@8.5.2(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/checkbox': 4.2.2(@types/node@22.18.1)
-      '@inquirer/confirm': 5.1.16(@types/node@22.18.1)
-      '@inquirer/editor': 4.2.18(@types/node@22.18.1)
-      '@inquirer/expand': 4.0.18(@types/node@22.18.1)
-      '@inquirer/input': 4.2.2(@types/node@22.18.1)
-      '@inquirer/number': 3.0.18(@types/node@22.18.1)
-      '@inquirer/password': 4.0.18(@types/node@22.18.1)
-      '@inquirer/rawlist': 4.1.6(@types/node@22.18.1)
-      '@inquirer/search': 3.1.1(@types/node@22.18.1)
-      '@inquirer/select': 4.3.2(@types/node@22.18.1)
+      '@inquirer/checkbox': 5.2.1(@types/node@26.1.2)
+      '@inquirer/confirm': 6.1.1(@types/node@26.1.2)
+      '@inquirer/editor': 5.2.2(@types/node@26.1.2)
+      '@inquirer/expand': 5.1.1(@types/node@26.1.2)
+      '@inquirer/input': 5.1.2(@types/node@26.1.2)
+      '@inquirer/number': 4.1.1(@types/node@26.1.2)
+      '@inquirer/password': 5.1.1(@types/node@26.1.2)
+      '@inquirer/rawlist': 5.3.1(@types/node@26.1.2)
+      '@inquirer/search': 4.2.1(@types/node@26.1.2)
+      '@inquirer/select': 5.2.1(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/rawlist@4.1.6(@types/node@22.18.1)':
+  '@inquirer/rawlist@5.3.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/search@3.1.1(@types/node@22.18.1)':
+  '@inquirer/search@4.2.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/select@4.3.2(@types/node@22.18.1)':
+  '@inquirer/select@5.2.1(@types/node@26.1.2)':
     dependencies:
-      '@inquirer/core': 10.2.0(@types/node@22.18.1)
-      '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@22.18.1)
-      ansi-escapes: 4.3.2
-      yoctocolors-cjs: 2.1.3
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@26.1.2)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@26.1.2)
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
-  '@inquirer/type@3.0.8(@types/node@22.18.1)':
+  '@inquirer/type@4.0.7(@types/node@26.1.2)':
     optionalDependencies:
-      '@types/node': 22.18.1
+      '@types/node': 26.1.2
 
   '@noble/ciphers@1.3.0': {}
 
@@ -845,18 +913,9 @@ snapshots:
 
   '@noble/hashes@1.8.0': {}
 
-  '@rhinestone/sdk@2.0.0-beta.38(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
+  '@rhinestone/sdk@2.2.1(viem@2.55.11(typescript@7.0.2))':
     dependencies:
-      '@rhinestone/shared-configs': 1.7.0(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))
-      solady: 0.1.26
-      viem: 2.45.0(typescript@5.9.2)
-    transitivePeerDependencies:
-      - typescript
-
-  '@rhinestone/shared-configs@1.7.0(typescript@5.9.2)(viem@2.45.0(typescript@5.9.2))':
-    dependencies:
-      typescript: 5.9.2
-      viem: 2.45.0(typescript@5.9.2)
+      viem: 2.55.11(typescript@7.0.2)
 
   '@scure/base@1.2.6': {}
 
@@ -871,93 +930,139 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/base': 1.2.6
 
-  '@types/node@22.18.1':
+  '@types/node@26.1.2':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 8.3.0
 
-  abitype@1.1.0(typescript@5.9.2):
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  abitype@1.2.3(typescript@7.0.2):
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 7.0.2
 
-  abitype@1.2.3(typescript@5.9.2):
+  abitype@1.3.0(typescript@7.0.2):
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 7.0.2
 
-  ansi-escapes@4.3.2:
-    dependencies:
-      type-fest: 0.21.3
-
-  ansi-regex@5.0.1: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
-  chardet@2.1.0: {}
+  chardet@2.2.0: {}
 
   cli-width@4.1.0: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
+  dotenv@17.4.2: {}
 
-  color-name@1.1.4: {}
-
-  dotenv@16.6.1: {}
-
-  emoji-regex@8.0.0: {}
-
-  esbuild@0.25.9:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.9
-      '@esbuild/android-arm': 0.25.9
-      '@esbuild/android-arm64': 0.25.9
-      '@esbuild/android-x64': 0.25.9
-      '@esbuild/darwin-arm64': 0.25.9
-      '@esbuild/darwin-x64': 0.25.9
-      '@esbuild/freebsd-arm64': 0.25.9
-      '@esbuild/freebsd-x64': 0.25.9
-      '@esbuild/linux-arm': 0.25.9
-      '@esbuild/linux-arm64': 0.25.9
-      '@esbuild/linux-ia32': 0.25.9
-      '@esbuild/linux-loong64': 0.25.9
-      '@esbuild/linux-mips64el': 0.25.9
-      '@esbuild/linux-ppc64': 0.25.9
-      '@esbuild/linux-riscv64': 0.25.9
-      '@esbuild/linux-s390x': 0.25.9
-      '@esbuild/linux-x64': 0.25.9
-      '@esbuild/netbsd-arm64': 0.25.9
-      '@esbuild/netbsd-x64': 0.25.9
-      '@esbuild/openbsd-arm64': 0.25.9
-      '@esbuild/openbsd-x64': 0.25.9
-      '@esbuild/openharmony-arm64': 0.25.9
-      '@esbuild/sunos-x64': 0.25.9
-      '@esbuild/win32-arm64': 0.25.9
-      '@esbuild/win32-ia32': 0.25.9
-      '@esbuild/win32-x64': 0.25.9
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   eventemitter3@5.0.1: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fsevents@2.3.3:
     optional: true
 
-  get-tsconfig@4.10.1:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
-
-  iconv-lite@0.6.3:
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
-  is-fullwidth-code-point@3.0.0: {}
-
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.21.0):
     dependencies:
-      ws: 8.18.3
+      ws: 8.21.0
 
-  mute-stream@2.0.0: {}
+  mute-stream@3.0.0: {}
 
-  ox@0.11.3(typescript@5.9.2):
+  ox@0.14.33(typescript@7.0.2):
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/ciphers': 1.3.0
@@ -965,67 +1070,63 @@ snapshots:
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.2)
+      abitype: 1.2.3(typescript@7.0.2)
       eventemitter3: 5.0.1
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 7.0.2
     transitivePeerDependencies:
       - zod
-
-  resolve-pkg-maps@1.0.0: {}
 
   safer-buffer@2.1.2: {}
 
   signal-exit@4.1.0: {}
 
-  solady@0.1.26: {}
-
-  string-width@4.2.3:
+  tsx@4.23.9:
     dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
-
-  tsx@4.20.5:
-    dependencies:
-      esbuild: 0.25.9
-      get-tsconfig: 4.10.1
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
-  type-fest@0.21.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
-  typescript@5.9.2: {}
+  undici-types@8.3.0: {}
 
-  undici-types@6.21.0: {}
-
-  viem@2.45.0(typescript@5.9.2):
+  viem@2.55.11(typescript@7.0.2):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
-      abitype: 1.2.3(typescript@5.9.2)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.11.3(typescript@5.9.2)
-      ws: 8.18.3
+      abitype: 1.2.3(typescript@7.0.2)
+      isows: 1.0.7(ws@8.21.0)
+      ox: 0.14.33(typescript@7.0.2)
+      ws: 8.21.0
     optionalDependencies:
-      typescript: 5.9.2
+      typescript: 7.0.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
       - zod
 
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  ws@8.18.3: {}
-
-  yoctocolors-cjs@2.1.3: {}
+  ws@8.21.0: {}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,7 +126,10 @@ export const collectUserInput = async (): Promise<{
     choices,
   })
 
-  const targetTokens = await checkbox({
+  // Widened to string[]: the "Arbitrary token" entry is replaced in place with
+  // a user-supplied address below, which @inquirer/prompts v8's literal-union
+  // return type would otherwise reject.
+  const targetTokens: string[] = await checkbox({
     message: 'Select tokens to transfer on the target chain',
     choices: [
       { name: 'ETH', value: 'ETH' },
@@ -179,7 +182,8 @@ export const collectUserInput = async (): Promise<{
     choices,
   })
 
-  const sourceTokens = await checkbox({
+  // Widened to string[] for the same reason as targetTokens above.
+  const sourceTokens: string[] = await checkbox({
     message: 'Select source tokens to use (optional)',
     choices: [
       { name: 'ETH', value: 'ETH' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import {
   type IntentResult,
   type ParsedToken,
   type SourceAssets,
+  type SourceTokens,
 } from './types.js'
 import {
   getChain,
@@ -31,9 +32,16 @@ import {
   getEvmChain,
   getLocalForkRpcUrl,
   isNonEvmChain,
+  SDK_RPC_OVERRIDES,
+  toSdkDestinationChain,
 } from './utils/chains.js'
 import { getEnvironment } from './utils/environments.js'
-import { convertTokenAmount, getDecimals } from './utils/tokens.js'
+import { loadRegistry } from './utils/registry.js'
+import {
+  convertTokenAmount,
+  getDecimals,
+  resolveTokenAddress,
+} from './utils/tokens.js'
 
 export function ts() {
   return new Date().toISOString().replace(/T/, ' ').replace(/\..+/, '')
@@ -56,16 +64,70 @@ const logTimingSummary = (
   )
 }
 
-const resolveSourceAssets = async (sourceAssets: SourceAssets) => {
-  // Format 1: string[] → SimpleTokenList, pass as-is
+/**
+ * Expand a plain symbol list into a per-chain address map.
+ *
+ * Deliberately NOT the SDK's flat `SimpleTokenList`, even though that is the
+ * shape a bare list maps onto: `adaptSourceAssets` only sends `chainIds`
+ * alongside `tokens` when `sourceChains` is set, so an unscoped list arrives as
+ * a bare `{ tokens: [...] }` that the orchestrator matches against nothing —
+ * answering `No balances available` on a provably funded account. Under
+ * beta.38 that same field carried *symbols* and matched globally; v2's switch
+ * to addresses is what made the unscoped form unusable. A per-chain map is
+ * scoped by construction, so it behaves the same with or without `sourceChains`.
+ */
+const expandSymbolList = async (
+  symbols: string[],
+  sourceChainIds: number[],
+  targetChainId: number,
+): Promise<Record<number, string[]>> => {
+  const registry = await loadRegistry()
+  // With no explicit `sourceChains`, fall back to every chain that can actually
+  // *be* a source: EVM only, and on the same side of the mainnet/testnet split
+  // as the target. Handing the orchestrator a virtual chain here is a hard 400
+  // (`Unsupported chain id in access list: 1337`), not a skipped entry.
+  const chainIds =
+    sourceChainIds.length > 0
+      ? sourceChainIds
+      : registry.sourceChainIds(registry.isTestnet(targetChainId))
+  const chainTokenMap: Record<number, string[]> = {}
+  for (const chainId of chainIds) {
+    const tokens = symbols.flatMap((symbolOrAddress) => {
+      const entry = registry.resolveToken(chainId, symbolOrAddress)
+      return entry ? [entry.address] : []
+    })
+    if (tokens.length > 0) chainTokenMap[chainId] = tokens
+  }
+  if (Object.keys(chainTokenMap).length === 0) {
+    throw new Error(
+      `None of [${symbols.join(', ')}] resolve on any source chain (facts v${registry.version}).`,
+    )
+  }
+  return chainTokenMap
+}
+
+// SDK v2 takes addresses throughout `sourceAssets` — `SimpleTokenList` is
+// `Address[]`, `ChainTokenMap` is `Record<chainId, Address[]>`, and
+// `ExactInputConfig.address` is an `Address`. Intent files stay symbol-based,
+// so every shape is resolved here.
+const resolveSourceAssets = async (
+  sourceAssets: SourceAssets,
+  sourceChainIds: number[],
+  targetChainId: number,
+) => {
+  // Format 1: a plain symbol list → per-chain map (see expandSymbolList).
   if (
     Array.isArray(sourceAssets) &&
     sourceAssets.every((item) => typeof item === 'string')
   ) {
-    return sourceAssets as string[]
+    return expandSymbolList(
+      sourceAssets as string[],
+      sourceChainIds,
+      targetChainId,
+    )
   }
 
-  // Format 3: ExactInputConfig[] → resolve chain names and amounts
+  // Format 3: ExactInputConfig[] → resolve chain names, token addresses, amounts
   if (Array.isArray(sourceAssets)) {
     const configs = sourceAssets as {
       chain: string
@@ -77,7 +139,10 @@ const resolveSourceAssets = async (sourceAssets: SourceAssets) => {
       const chain = getChain(config.chain)
       const entry: { chain: typeof chain; address: string; amount?: bigint } = {
         chain,
-        address: config.token,
+        address: await resolveTokenAddress({
+          tokenSymbolOrAddress: config.token,
+          chainId: chain.id,
+        }),
       }
       if (config.amount) {
         const decimals = await getDecimals({
@@ -95,9 +160,47 @@ const resolveSourceAssets = async (sourceAssets: SourceAssets) => {
   const chainTokenMap: Record<number, string[]> = {}
   for (const [chainName, tokens] of Object.entries(sourceAssets)) {
     const chain = getChain(chainName)
-    chainTokenMap[chain.id] = tokens
+    chainTokenMap[chain.id] = await Promise.all(
+      tokens.map((token) =>
+        resolveTokenAddress({ tokenSymbolOrAddress: token, chainId: chain.id }),
+      ),
+    )
   }
   return chainTokenMap
+}
+
+/**
+ * The legacy `sourceTokens` field, resolved to addresses for SDK v2. Kept
+ * separate from `resolveSourceAssets` because its object form is keyed by a
+ * bare `{ id }` rather than a chain name.
+ */
+const resolveLegacySourceTokens = async (
+  sourceTokens: SourceTokens,
+  sourceChainIds: number[],
+  targetChainId: number,
+) => {
+  if (sourceTokens.every((token) => typeof token === 'string')) {
+    return expandSymbolList(
+      sourceTokens as string[],
+      sourceChainIds,
+      targetChainId,
+    )
+  }
+
+  const entries = sourceTokens as {
+    chain: { id: number }
+    address: string
+    amount?: string
+  }[]
+  return Promise.all(
+    entries.map(async (entry) => ({
+      ...entry,
+      address: await resolveTokenAddress({
+        tokenSymbolOrAddress: entry.address,
+        chainId: entry.chain.id,
+      }),
+    })),
+  )
 }
 
 /** Resolve human-friendly auxiliaryFunds to SDK format. Keys must be addresses. */
@@ -159,6 +262,7 @@ export const createRhinestoneAccount = async (
     apiKey: environment.apiKey,
     endpointUrl: environment.url,
     useDevContracts: environment.useDevContracts,
+    provider: { type: 'custom', urls: SDK_RPC_OVERRIDES },
   })
 
   if (accountType === 'eoa') {
@@ -175,6 +279,17 @@ export const createRhinestoneAccount = async (
       type: 'ecdsa' as const,
       accounts: [owner],
     },
+    // Pinned explicitly rather than left to the SDK default, because the
+    // account address is derived from this descriptor: SDK v2 moved the default
+    // from Nexus 1.2.0 to 1.2.1, which silently re-derives every account to a
+    // new address and shows up as `No balances available` on an account that is
+    // provably funded on-chain. Naming the version means the next default bump
+    // is a visible diff here, not a stranded test account.
+    //
+    // Test float was migrated 1.2.0 → 1.2.1 on 2026-08-06:
+    //   prod 0x5893b690…291CF → 0x5F52cca9…2446c
+    //   dev  0x4326Ae48…1a428 → 0x23c66979…2A4CE
+    account: { type: 'nexus' as const, version: '1.2.1' as const },
   })
 }
 
@@ -264,6 +379,10 @@ export const processIntent = async (
       ...(isAddress(targetToken.symbol)
         ? { address: targetToken.symbol as Address }
         : {}),
+      resolvedAddress: await resolveTokenAddress({
+        tokenSymbolOrAddress: targetToken.symbol,
+        chainId: targetChain.id,
+      }),
     }
 
     if (targetToken.amount) {
@@ -312,17 +431,15 @@ export const processIntent = async (
             },
           ]
 
-  // prepare the token requests. SDK accepts symbol or address here, so pass
-  // the user's string through untouched.
+  // prepare the token requests. SDK v2 requires a hex address on EVM chains
+  // (symbols are rejected outright), so use the registry-resolved address.
   const tokenRequests = targetTokens.map((token: ParsedToken) => {
+    const address = (token.resolvedAddress ?? token.symbol) as Address
     if (token.amount) {
-      return {
-        address: token.symbol as Address,
-        amount: token.amount,
-      }
+      return { address, amount: token.amount }
     }
 
-    return { address: token.symbol as Address }
+    return { address }
   })
 
   // prepare the source assets label
@@ -379,9 +496,17 @@ export const processIntent = async (
 
   // resolve source assets: prefer sourceAssets over sourceTokens
   const resolvedSourceAssets = intent.sourceAssets
-    ? await resolveSourceAssets(intent.sourceAssets)
+    ? await resolveSourceAssets(
+        intent.sourceAssets,
+        sourceChains.map((chain) => chain.id),
+        targetChain.id,
+      )
     : intent.sourceTokens?.length
-      ? intent.sourceTokens
+      ? await resolveLegacySourceTokens(
+          intent.sourceTokens,
+          sourceChains.map((chain) => chain.id),
+          targetChain.id,
+        )
       : undefined
 
   // resolve auxiliary funds if provided
@@ -391,7 +516,7 @@ export const processIntent = async (
 
   const transactionDetails = {
     sourceChains: sourceChains.length > 0 ? sourceChains : undefined,
-    targetChain,
+    targetChain: toSdkDestinationChain(targetChain),
     calls,
     tokenRequests,
     sponsored: intent.sponsored,

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,14 @@ export type ParsedToken = {
   symbol: string
   /** Set only when `symbol` is an address; needed to build destination ERC20 transfer calls. */
   address?: Address
+  /**
+   * The address handed to the SDK. Always set on EVM chains — SDK v2 rejects
+   * symbols in `tokenRequests` — and resolved from the chain registry when the
+   * user gave a symbol. Deliberately separate from `address`: that one still
+   * means "the user supplied an address", which is what decides whether a real
+   * destination ERC20 transfer is built or a no-op call.
+   */
+  resolvedAddress?: string
   amount?: bigint
 }
 

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -55,6 +55,20 @@ export const NON_EVM_CHAIN_IDS: ReadonlySet<number> = new Set(
 export const isNonEvmChain = (chainId: number): boolean =>
   NON_EVM_CHAIN_IDS.has(chainId)
 
+/**
+ * Strip the shimmed `id` before handing a destination to the SDK. v2 types the
+ * destination as `Chain | NonEvmChain` and `NonEvmChain` has **no** `id`, so the
+ * presence of one is what makes it take the EVM path — and for HyperCore that
+ * lands on the 1337 trap described above.
+ */
+export const toSdkDestinationChain = (
+  chain: Chain | DestinationChainWithId,
+): Chain | NonEvmChain => {
+  if (!isNonEvmChain(chain.id)) return chain as Chain
+  const { id: _id, ...descriptor } = chain as DestinationChainWithId
+  return descriptor
+}
+
 // viem re-exports some non-Chain values (e.g. defineChain). Guard the
 // .name / .id access so the find() doesn't throw on those.
 const isViemChain = (value: unknown): value is Chain => {
@@ -97,6 +111,21 @@ export const getChainById = (chainId: number): Chain => {
     throw new Error(`Chain with id ${chainId} is not supported.`)
   }
   return chain as Chain
+}
+
+/**
+ * Per-chain RPC overrides handed to the SDK as `provider: { type: 'custom' }`.
+ *
+ * The 1337-is-viem's-`localhost` collision documented on NON_EVM_CHAINS above
+ * exists inside the SDK too: v2's own id↔caip2 table calls HyperCore 1337 and
+ * resolves it through viem, so any RPC-needing step on a HyperCore destination
+ * goes to `127.0.0.1:8545` and fails with `ECONNREFUSED` — which reads as a
+ * broken local environment, not a chain-resolution bug. HyperEVM is the right
+ * answer: it is what the orchestrator settles HyperCore on, and the registry
+ * gives 999 and 1337 the same USDC address.
+ */
+export const SDK_RPC_OVERRIDES: Record<number, string> = {
+  1337: viemChains.hyperEvm.rpcUrls.default.http[0],
 }
 
 // Local anvil fork RPC endpoints, keyed by chainId. Ports follow the e2e stack

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -1,0 +1,165 @@
+import { type Address, isAddress } from 'viem'
+
+/**
+ * Runtime chain/token registry, read from the signed chain-facts artifact that
+ * the orchestrator itself boots from.
+ *
+ * SDK v2 removed its bundled token registry: `normalizeTokenAddress` now
+ * requires a hex address on every EVM chain and rejects symbols outright. The
+ * orchestrator's own `GET /chains` can't fill the gap either — it reports
+ * `supportedTokens: 'all'` for most chains (Base and Robinhood Chain included),
+ * so it advertises no symbol table for them.
+ *
+ * Fetching this at runtime rather than depending on a pinned
+ * `@rhinestone/shared-configs` is deliberate: a pinned registry is exactly what
+ * made Robinhood Chain (4663) unusable here while it was live in prod. The
+ * artifact is global — there is no per-env staging of it — so a chain appears
+ * to this CLI as soon as it is published, with no dependency bump.
+ *
+ * Skew to be aware of: consumers load the artifact at boot, so a running
+ * orchestrator can be a version behind `latest.json`. That only ever affects a
+ * brand-new chain or token, and it surfaces as a clear orchestrator rejection
+ * rather than a silently wrong route.
+ */
+
+const FACTS_URL = 'https://facts.rhinestone.dev/latest.json'
+
+export type RegistryToken = {
+  symbol: string
+  address: Address
+  decimals: number
+}
+
+type FactsToken = {
+  symbol: string
+  address: string
+  decimals: number
+}
+
+type FactsChain = {
+  caip2: string
+  name: string
+  vmType: string
+  network: string
+  tokens?: FactsToken[]
+}
+
+type FactsArtifact = {
+  version: string
+  chains: Record<string, FactsChain>
+}
+
+export type Registry = {
+  version: string
+  /** Chain ids the artifact describes. */
+  chainIds: number[]
+  /**
+   * Chain ids usable as an intent *source*: EVM, and matching `testnet`.
+   * Solana/Tron/HyperCore are destination-only here, and the orchestrator
+   * rejects them outright in a source access list
+   * (`Unsupported chain id in access list: 1337`).
+   */
+  sourceChainIds: (testnet: boolean) => number[]
+  /** Whether the artifact marks this chain as a testnet. Unknown ids read as mainnet. */
+  isTestnet: (chainId: number) => boolean
+  /**
+   * Resolve a user-supplied token string on a chain. An address passes through
+   * (looked up for decimals when known); a symbol is matched case-insensitively.
+   */
+  resolveToken: (
+    chainId: number,
+    symbolOrAddress: string,
+  ) => RegistryToken | undefined
+  /** Chain id for a viem-style name with spaces stripped, e.g. `robinhoodchain`. */
+  getChainIdByName: (normalizedName: string) => number | undefined
+}
+
+const normalizeName = (name: string) => name.replace(/ /g, '').toLowerCase()
+
+const buildRegistry = (artifact: FactsArtifact): Registry => {
+  const tokensByChain = new Map<number, RegistryToken[]>()
+  const chainIdByName = new Map<string, number>()
+  const evmChains = new Map<number, { testnet: boolean }>()
+  const testnetChainIds = new Set<number>()
+
+  for (const [key, chain] of Object.entries(artifact.chains)) {
+    const chainId = Number(key)
+    if (!Number.isFinite(chainId)) continue
+    chainIdByName.set(normalizeName(chain.name), chainId)
+    if (chain.network === 'testnet') testnetChainIds.add(chainId)
+    if (chain.vmType === 'evm' && chain.caip2.startsWith('eip155:')) {
+      evmChains.set(chainId, { testnet: chain.network === 'testnet' })
+    }
+    // Only EVM chains carry hex addresses we can hand to the SDK; Solana/Tron
+    // token identifiers are passed through untouched by `normalizeTokenAddress`.
+    const tokens = (chain.tokens ?? []).flatMap<RegistryToken>((token) =>
+      isAddress(token.address)
+        ? [
+            {
+              symbol: token.symbol,
+              // Lowercased on purpose. The artifact publishes checksummed
+              // addresses; the orchestrator echoes and matches lowercase, and
+              // its `sourceAssets.tokens` filter is compared as a raw string —
+              // so a checksummed address matches no balance and comes back as
+              // `No balances available` on a demonstrably funded account.
+              address: token.address.toLowerCase() as Address,
+              decimals: token.decimals,
+            },
+          ]
+        : [],
+    )
+    tokensByChain.set(chainId, tokens)
+  }
+
+  return {
+    version: artifact.version,
+    chainIds: [...tokensByChain.keys()],
+    sourceChainIds: (testnet) =>
+      [...evmChains.entries()]
+        .filter(([, meta]) => meta.testnet === testnet)
+        .map(([chainId]) => chainId),
+    isTestnet: (chainId) => testnetChainIds.has(chainId),
+    resolveToken: (chainId, symbolOrAddress) => {
+      const tokens = tokensByChain.get(chainId) ?? []
+      if (isAddress(symbolOrAddress)) {
+        const lower = symbolOrAddress.toLowerCase()
+        return (
+          tokens.find((t) => t.address.toLowerCase() === lower) ?? {
+            // Unknown-to-the-registry address: still a valid input for the SDK,
+            // but decimals have to come from the chain. Signalled with -1 so
+            // callers fall through to an RPC read rather than trusting a guess.
+            symbol: symbolOrAddress,
+            address: symbolOrAddress as Address,
+            decimals: -1,
+          }
+        )
+      }
+      const upper = symbolOrAddress.toUpperCase()
+      return tokens.find((t) => t.symbol.toUpperCase() === upper)
+    },
+    getChainIdByName: (name) => chainIdByName.get(normalizeName(name)),
+  }
+}
+
+let cached: Promise<Registry> | undefined
+
+/** Load the chain-facts artifact once per process. */
+export const loadRegistry = (): Promise<Registry> => {
+  if (!cached) {
+    cached = (async () => {
+      const response = await fetch(FACTS_URL)
+      if (!response.ok) {
+        throw new Error(
+          `Failed to load the chain registry from ${FACTS_URL}: ${response.status} ${response.statusText}`,
+        )
+      }
+      return buildRegistry((await response.json()) as FactsArtifact)
+    })().catch((error) => {
+      // Don't cache a failed load — a transient network blip shouldn't poison
+      // every later lookup in a long `--async` replay.
+      cached = undefined
+      throw error
+    })
+  }
+  return cached
+}

--- a/src/utils/registry.ts
+++ b/src/utils/registry.ts
@@ -63,6 +63,12 @@ export type Registry = {
   /** Whether the artifact marks this chain as a testnet. Unknown ids read as mainnet. */
   isTestnet: (chainId: number) => boolean
   /**
+   * The chain's VM per the artifact (`evm` / `svm` / `tvm`), or undefined if it
+   * isn't listed. This is the only reliable answer to "are this chain's token
+   * identifiers hex addresses?" — see `resolveTokenAddress`.
+   */
+  getVmType: (chainId: number) => string | undefined
+  /**
    * Resolve a user-supplied token string on a chain. An address passes through
    * (looked up for decimals when known); a symbol is matched case-insensitively.
    */
@@ -81,11 +87,13 @@ const buildRegistry = (artifact: FactsArtifact): Registry => {
   const chainIdByName = new Map<string, number>()
   const evmChains = new Map<number, { testnet: boolean }>()
   const testnetChainIds = new Set<number>()
+  const vmTypeByChain = new Map<number, string>()
 
   for (const [key, chain] of Object.entries(artifact.chains)) {
     const chainId = Number(key)
     if (!Number.isFinite(chainId)) continue
     chainIdByName.set(normalizeName(chain.name), chainId)
+    vmTypeByChain.set(chainId, chain.vmType)
     if (chain.network === 'testnet') testnetChainIds.add(chainId)
     if (chain.vmType === 'evm' && chain.caip2.startsWith('eip155:')) {
       evmChains.set(chainId, { testnet: chain.network === 'testnet' })
@@ -119,6 +127,7 @@ const buildRegistry = (artifact: FactsArtifact): Registry => {
         .filter(([, meta]) => meta.testnet === testnet)
         .map(([chainId]) => chainId),
     isTestnet: (chainId) => testnetChainIds.has(chainId),
+    getVmType: (chainId) => vmTypeByChain.get(chainId),
     resolveToken: (chainId, symbolOrAddress) => {
       const tokens = tokensByChain.get(chainId) ?? []
       if (isAddress(symbolOrAddress)) {

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -7,7 +7,8 @@ import {
   parseUnits,
 } from 'viem'
 import type { Token } from '../types.js'
-import { getChainById, NON_EVM_CHAINS } from './chains.js'
+import { getChainById, isNonEvmChain, NON_EVM_CHAINS } from './chains.js'
+import { loadRegistry } from './registry.js'
 
 const KNOWN_DECIMALS: Record<string, number> = {
   ETH: 18,
@@ -78,10 +79,15 @@ export const getDecimals = async ({
     )
   }
   if (!isAddress(tokenSymbolOrAddress)) {
+    // The registry is authoritative and per-chain (USDC is 6 decimals almost
+    // everywhere, but the table below is a guess and the registry is not).
+    const registry = await loadRegistry()
+    const entry = registry.resolveToken(chainId, tokenSymbolOrAddress)
+    if (entry && entry.decimals >= 0) return entry.decimals
     const known = KNOWN_DECIMALS[tokenSymbolOrAddress.toUpperCase()]
     if (known !== undefined) return known
     throw new Error(
-      `Unknown symbol '${tokenSymbolOrAddress}'. Pass an address or use one of: ${Object.keys(KNOWN_DECIMALS).join(', ')}`,
+      `Unknown symbol '${tokenSymbolOrAddress}' on chain ${chainId}. Pass an address, or use a symbol the chain registry knows for that chain.`,
     )
   }
   const cacheKey = `${chainId}:${tokenSymbolOrAddress.toLowerCase()}`
@@ -98,6 +104,34 @@ export const getDecimals = async ({
   })
   decimalsCache.set(cacheKey, decimals)
   return decimals
+}
+
+/**
+ * Turn a user-supplied token string into the hex address SDK v2 requires.
+ *
+ * v2's `normalizeTokenAddress` rejects symbols on every EVM chain, so this is
+ * the boundary where the intent files' human-friendly `"USDC"` becomes an
+ * address. Non-EVM destinations are passed through untouched — the SDK forwards
+ * their mint/contract identifiers verbatim.
+ */
+export const resolveTokenAddress = async ({
+  tokenSymbolOrAddress,
+  chainId,
+}: {
+  tokenSymbolOrAddress: string
+  chainId: number
+}): Promise<string> => {
+  if (isAddress(tokenSymbolOrAddress)) return tokenSymbolOrAddress
+  if (isNonEvmChain(chainId)) return tokenSymbolOrAddress
+
+  const registry = await loadRegistry()
+  const entry = registry.resolveToken(chainId, tokenSymbolOrAddress)
+  if (!entry) {
+    throw new Error(
+      `Cannot resolve token '${tokenSymbolOrAddress}' on chain ${chainId}: the chain registry (facts v${registry.version}) lists no such symbol there. Pass the token address instead.`,
+    )
+  }
+  return entry.address
 }
 
 export const convertTokenAmount = async ({

--- a/src/utils/tokens.ts
+++ b/src/utils/tokens.ts
@@ -111,8 +111,17 @@ export const getDecimals = async ({
  *
  * v2's `normalizeTokenAddress` rejects symbols on every EVM chain, so this is
  * the boundary where the intent files' human-friendly `"USDC"` becomes an
- * address. Non-EVM destinations are passed through untouched — the SDK forwards
- * their mint/contract identifiers verbatim.
+ * address. Only chains whose tokens are genuinely opaque identifiers — Solana
+ * mints, Tron contracts — are passed through untouched.
+ *
+ * That question is asked of the registry's VM type and NOT of `isNonEvmChain`,
+ * because the two disagree on HyperCore and only one of them is about token
+ * addressing. `isNonEvmChain(1337)` is true (HyperCore has no viem chain and no
+ * RPC, which is what that predicate guards), but its tokens are ordinary
+ * HyperEVM ERC20s and SDK v2 parses `hypercore:mainnet` as EVM-settled id 1337
+ * — so a symbol here dies at `Expected a token address on EVM chain 1337`,
+ * before routing. The artifact says `vmType: 'evm'` for 1337 and `svm`/`tvm`
+ * for Solana/Tron, which is exactly the distinction needed.
  */
 export const resolveTokenAddress = async ({
   tokenSymbolOrAddress,
@@ -122,9 +131,14 @@ export const resolveTokenAddress = async ({
   chainId: number
 }): Promise<string> => {
   if (isAddress(tokenSymbolOrAddress)) return tokenSymbolOrAddress
-  if (isNonEvmChain(chainId)) return tokenSymbolOrAddress
 
   const registry = await loadRegistry()
+  const vmType = registry.getVmType(chainId)
+  // Unlisted chain: fall back to the local set so Solana/Tron still pass
+  // through if the artifact ever stops describing them.
+  const opaqueTokenIds = vmType ? vmType !== 'evm' : isNonEvmChain(chainId)
+  if (opaqueTokenIds) return tokenSymbolOrAddress
+
   const entry = registry.resolveToken(chainId, tokenSymbolOrAddress)
   if (!entry) {
     throw new Error(


### PR DESCRIPTION
[skip-linear] — tooling maintenance on the sim-tests CLI.

Moves off `@rhinestone/sdk` `2.0.0-beta.38` to **`2.2.1`**, plus viem 2.45→2.55, biome 2.3→2.5, inquirer 7→8, dotenv 16→17, typescript 5→7, and the rest to latest.

## Why

**Robinhood Chain (4663) has been live in prod but unroutable from this repo.** Two pins blocked it independently:

- viem 2.45.0 has no Robinhood definition at all → `getChain` threw before anything else ran
- beta.38 bundled shared-configs 1.7.0 (22 chains, no 4663) → `UnsupportedChainError` before any network call

## What v2 stable breaks, and how it's handled

**It removes the bundled token registry.** `normalizeTokenAddress` now requires a hex address on every EVM chain and rejects symbols — so this breaks *every* symbol-based intent in the repo, not just Robinhood ones. The orchestrator's `GET /chains` can't substitute: it reports `supportedTokens: 'all'` for most chains (Base and Robinhood included) and publishes no symbol table.

`src/utils/registry.ts` resolves symbols from the chain-facts artifact the orchestrator itself boots from, **fetched at runtime rather than pinned to a package**. That's the design point worth pushing back on if you disagree: a pinned registry is exactly what made a live chain unusable here, and an unpinned one picks up new chains with no dependency bump. Cost is a network fetch at startup and possible skew against an orchestrator running an older facts version — which only affects brand-new tokens and fails loudly.

**It changes the derived account address.** v2 moved the default account descriptor from Nexus 1.2.0 to 1.2.1, which silently re-derives every account and surfaces as `No balances available` on a provably funded account. The test float was migrated first (35 same-chain transfers, $0.90 sponsored gas):

| | from | to |
|---|---|---|
| prod | `0x5893b690…291CF` | `0x5F52cca9…2446c` |
| dev | `0x4326Ae48…1a428` | `0x23c66979…2A4CE` |

The descriptor is now pinned **explicitly** so the next default bump is a visible diff here rather than a stranded account.

## Other fixes, all found by running real intents

- A bare `sourceAssets: ["USDC"]` is expanded to a per-chain map instead of v2's flat `SimpleTokenList` — the flat form is only honoured alongside `chainIds`, which the SDK sends only when `sourceChains` is set, so unscoped it matched nothing and returned `No balances available` on a funded account. The fallback set is EVM-only and network-matched (a virtual chain in a source access list is a hard 400).
- `SDK_RPC_OVERRIDES` points chain 1337 at HyperEVM: v2's own id↔caip2 table calls HyperCore 1337 and resolves it through viem, where 1337 is `localhost`, so HyperCore destinations sent `eth_getCode` to `127.0.0.1:8545`.
- `toSdkDestinationChain` strips our shimmed `id` before handing a descriptor to the SDK, since v2's `NonEvmChain` has no `id` and classifies on its absence.
- `ParsedToken.resolvedAddress` is kept separate from `address` so symbol-only intents still emit a no-op call instead of silently starting to build real destination transfers.

## Testing

Route-only against **prod on real balances**: Robinhood by symbol / by address / scoped list / chain map, auto-routing, Base, HyperCore, Solana, and both legacy `sourceTokens` forms. Plus `pnpm address`, `pnpm balance` (mainnet + testnet), `pnpm app-fee-balance`, `--account-type eoa`. The execute path got 35 real transactions during the migration.

Not exercised: `pnpm new`'s interactive prompts (the change there is a type widening with no runtime effect).

## Also

Adds **`pnpm typecheck`** — which is how the inquirer v8 type errors in this diff were caught. `tsx` transpiles without checking and there's no CI, so nothing else would have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)